### PR TITLE
fix: types 

### DIFF
--- a/src/commands/create-expo-stack.ts
+++ b/src/commands/create-expo-stack.ts
@@ -8,7 +8,7 @@ interface CliFlags {
   importAlias: string;
 }
 
-const availablePackages = ["nativewind", "react-navigation", "expo-router"];
+const availablePackages = ["nativewind", "react-navigation", "expo-router"] as const;
 
 type NavigationTypes = "stack" | "tab" | {};
 


### PR DESCRIPTION
### Description
`availablePackages` wasn't using `as const` which caused the below type to be an array of strings vs the values in the tuple

```ts
name: (typeof availablePackages)[number]; // string[]
```