### PR TITLE
fix(run-ignite): defaults and forward pkg mgr

### DIFF
--- a/src/utilities/runIgnite.ts
+++ b/src/utilities/runIgnite.ts
@@ -8,6 +8,7 @@ export async function runIgnite(toolbox: Toolbox) {
     print: { success },
     prompt: { ask },
     system,
+    strings: { pascalCase },
   } = toolbox;
 
   let projectName;
@@ -25,9 +26,12 @@ export async function runIgnite(toolbox: Toolbox) {
   }
 
   const packageManager = getPackageManager(toolbox);
+  // right now Ignite requires PascalCase for the project name
+  // unsure why, will ask the team and then probably fix it upstream
+  const formattedName = pascalCase(projectName);
 
   success('Running Ignite CLI to create an opinionated stack...')
-  await system.spawn(`npx ignite-cli@latest new ${projectName} --packager=${packageManager} --yes`, {
+  await system.spawn(`npx ignite-cli@latest new ${formattedName} --packager=${packageManager} --yes`, {
     shell: true,
     stdio: 'inherit',
   });

--- a/src/utilities/runIgnite.ts
+++ b/src/utilities/runIgnite.ts
@@ -1,9 +1,10 @@
 import { Toolbox } from "gluegun/build/types/domain/toolbox";
 import { DEFAULT_APP_NAME } from "../constants";
+import { getPackageManager } from "./getPackageManager";
 
 export async function runIgnite(toolbox: Toolbox) {
   const {
-    parameters: { first, options },
+    parameters: { first },
     print: { success },
     prompt: { ask },
     system,
@@ -23,8 +24,10 @@ export async function runIgnite(toolbox: Toolbox) {
     projectName = first;
   }
 
+  const packageManager = getPackageManager(toolbox);
+
   success('Running Ignite CLI to create an opinionated stack...')
-  await system.spawn(`npx ignite-cli@latest new ${projectName}${options.default && ` --yes`}`, {
+  await system.spawn(`npx ignite-cli@latest new ${projectName} --packager=${packageManager} --yes`, {
     shell: true,
     stdio: 'inherit',
   });


### PR DESCRIPTION
## What it does

- Fixes cli input to Ignite, removes some `undefined` string that got carried on into the name and project directory
- Forwards on the user's package manager choice from `create-expo-stack`

## What it looks like

`create-expo-stack CesIgnite2 --npm --ignite`

![image](https://github.com/danstepanov/create-expo-stack/assets/374022/b604ed7a-f8c4-4e85-bba1-76bdcfd84fa8)

`create-expo-stack CesIgnite --yarn --ignite`

![image](https://github.com/danstepanov/create-expo-stack/assets/374022/25976a14-2438-4cfc-85ee-0b26874b667f)
