### PR TITLE
Feat/bun pkg mgr

### DIFF
--- a/__tests__/cli-integration.test.ts
+++ b/__tests__/cli-integration.test.ts
@@ -12,7 +12,7 @@ const cli = async (cmd) =>
 jest.setTimeout(40000); // Set a 10-second timeout
 
 // Run tests for each package manager
-const packageManagers = [`npm`, `yarn`, `pnpm`]
+const packageManagers = [`npm`, `yarn`, `pnpm`, `bun`]
 
 test(`outputs version`, async () => {
   const output = await cli(`--version`)

--- a/src/utilities/getPackageManager.ts
+++ b/src/utilities/getPackageManager.ts
@@ -1,6 +1,6 @@
 import { Toolbox } from "gluegun/build/types/domain/toolbox";
 
-export type PackageManager = "npm" | "pnpm" | "yarn";
+export type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
 
 // Taken directly from the T3 codebase
 export function getPackageManager(toolbox: Toolbox): PackageManager {
@@ -11,6 +11,7 @@ export function getPackageManager(toolbox: Toolbox): PackageManager {
   if (options.npm) return 'npm';
   if (options.yarn) return 'yarn';
   if (options.pnpm) return 'pnpm';
+  if (options.bun) return 'bun';
 
   // This environment variable is set by npm and yarn but pnpm seems less consistent
   const userAgent = process.env.npm_config_user_agent;
@@ -19,9 +20,8 @@ export function getPackageManager(toolbox: Toolbox): PackageManager {
       return "yarn";
     } else if (userAgent.startsWith("pnpm")) {
       return "pnpm";
-      // TODO: Add support for bun
-      // } else if (userAgent.startsWith("bun")) {
-      //   return "bun";
+    } else if (userAgent.startsWith("bun")) {
+      return "bun";
     } else {
       return "npm";
     }

--- a/src/utilities/printOutput.ts
+++ b/src/utilities/printOutput.ts
@@ -59,6 +59,9 @@ export async function printOutput(
   } else if (packageManager === 'pnpm') {
     if (options.noInstall) info('pnpm install')
     info('pnpm run ios')
+  } else if (packageManager === 'bun') {
+    if (options.noInstall) info('bun install')
+    info('bun run ios')
   } else {
     if (options.noInstall) info('yarn install')
     info('yarn ios')

--- a/src/utilities/runIgnite.ts
+++ b/src/utilities/runIgnite.ts
@@ -29,9 +29,11 @@ export async function runIgnite(toolbox: Toolbox) {
   // right now Ignite requires PascalCase for the project name
   // unsure why, will ask the team and then probably fix it upstream
   const formattedName = pascalCase(projectName);
+  // bun is only available for @next version at the moment
+  const igniteVersion = packageManager === 'bun' ? 'next' : 'latest'
 
   success('Running Ignite CLI to create an opinionated stack...')
-  await system.spawn(`npx ignite-cli@latest new ${formattedName} --packager=${packageManager} --yes`, {
+  await system.spawn(`npx ignite-cli@${igniteVersion} new ${formattedName} --packager=${packageManager} --yes`, {
     shell: true,
     stdio: 'inherit',
   });


### PR DESCRIPTION
## What it does

- Adds `bun` as a package manager option for blazing fast installs
- Wires up `ignite-cli@next` when bun is used until it is finally released
- Adds test cases for `bun` package manager

## How it works

- Very fast zig things 🤣 
- `create-expo-stack MyApp --bun` or `create-expo-stack MyApp --ignite --bun`

![image](https://github.com/danstepanov/create-expo-stack/assets/374022/d2b63752-64b3-4441-83c2-46b2730232bc)

