### PR TITLE
Fix: Added declare module type for shorthand props

### DIFF
--- a/cli/src/templates/packages/tamagui/tamagui.config.ts.ejs
+++ b/cli/src/templates/packages/tamagui/tamagui.config.ts.ejs
@@ -117,4 +117,10 @@ const config = createTamagui({
 	}),
 });
 
+type AppConfig = typeof config;
+
+declare module "tamagui" {
+  	interface TamaguiCustomConfig extends AppConfig {}
+}
+
 export default config;

--- a/cli/src/templates/packages/tamagui/tamagui.config.ts.ejs
+++ b/cli/src/templates/packages/tamagui/tamagui.config.ts.ejs
@@ -119,6 +119,9 @@ const config = createTamagui({
 
 type AppConfig = typeof config;
 
+// Enable auto-completion of props shorthand (ex: jc="center") for Tamagui templates.
+// Docs: https://tamagui.dev/docs/core/configuration
+
 declare module "tamagui" {
   	interface TamaguiCustomConfig extends AppConfig {}
 }


### PR DESCRIPTION
When using the tamagui + expo router template, I noticed that shorthand props like `jc="center"` weren't being auto-suggested or auto-completed. This change fixes that, but let me know if there's a reason it was left out in the first place. 

Here's the section of the docs that references this: https://tamagui.dev/docs/core/configuration