### PR TITLE
Split copying assets into a separate task

### DIFF
--- a/cli/src/utilities/configureProjectFiles.ts
+++ b/cli/src/utilities/configureProjectFiles.ts
@@ -11,10 +11,6 @@ export function configureProjectFiles(
 ): string[] {
 	// Define the files common to all templates to be generated
 	const baseFiles = [
-		'base/assets/adaptive-icon.png',
-		'base/assets/favicon.png',
-		'base/assets/icon.png',
-		'base/assets/splash.png',
 		'base/tsconfig.json.ejs',
 		'base/app.json.ejs',
 		'base/App.tsx.ejs',

--- a/cli/src/utilities/copyBaseAssets.ts
+++ b/cli/src/utilities/copyBaseAssets.ts
@@ -1,0 +1,15 @@
+import { Toolbox } from 'gluegun/build/types/domain/toolbox'
+
+export async function copyBaseAssets(projectName: string, toolbox: Toolbox) {
+  return await toolbox.filesystem.copyAsync(
+    toolbox.filesystem.path(
+      toolbox.plugin.directory,
+      'templates',
+      'base/assets'
+    ),
+    toolbox.filesystem.path(projectName, 'assets'),
+    {
+      overwrite: true,
+    }
+  )
+}

--- a/cli/src/utilities/printOutput.ts
+++ b/cli/src/utilities/printOutput.ts
@@ -2,6 +2,7 @@ import { Toolbox } from 'gluegun/build/types/domain/toolbox'
 
 import { getPackageManager } from './getPackageManager'
 import { CliResults } from '../types'
+import { copyBaseAssets } from './copyBaseAssets'
 
 export async function printOutput(
 	cliResults: CliResults,
@@ -21,6 +22,10 @@ export async function printOutput(
 	highlight(`Initializing your project...`)
 
 	await Promise.all(formattedFiles)
+
+	info(``)
+	highlight(`Copying base assets...`)
+	await copyBaseAssets(projectName, toolbox)
 
 	// check if npm option is set, otherwise set based on what the system is configure to use
 	const packageManager = getPackageManager(toolbox)


### PR DESCRIPTION
Fixes: #30


The reason what that `toolbox.template.generate` was meant to be used with `.ejs`. 