### PR TITLE
Add react-refresh to overrides.

### DIFF
--- a/cli/src/templates/base/package.json.ejs
+++ b/cli/src/templates/base/package.json.ejs
@@ -94,6 +94,7 @@
     "resolutions": {
       "metro": "0.76.0",
       "metro-resolver": "0.76.0"
+      "react-refresh": "~0.14.0"
     },
     "overrides": {
       "metro": "0.76.0",

--- a/cli/src/templates/base/package.json.ejs
+++ b/cli/src/templates/base/package.json.ejs
@@ -97,7 +97,8 @@
     },
     "overrides": {
       "metro": "0.76.0",
-      "metro-resolver": "0.76.0"
+      "metro-resolver": "0.76.0",
+      "react-refresh": "~0.14.0"
     },
   <% } else { %>
     "main": "node_modules/expo/AppEntry.js",


### PR DESCRIPTION
Fixes #38

Tested locally - hot reloading works correctly on web after this update.