### PR TITLE
Update package.json.ejs

### DIFF
--- a/cli/src/templates/base/package.json.ejs
+++ b/cli/src/templates/base/package.json.ejs
@@ -93,7 +93,7 @@
   <% if (props.navigationPackage?.name === 'expo-router') { %>
     "resolutions": {
       "metro": "0.76.0",
-      "metro-resolver": "0.76.0"
+      "metro-resolver": "0.76.0",
       "react-refresh": "~0.14.0"
     },
     "overrides": {

--- a/cli/src/utilities/printOutput.ts
+++ b/cli/src/utilities/printOutput.ts
@@ -36,16 +36,17 @@ export async function printOutput(cliResults: CliResults, formattedFiles: any[],
 			shell: true,
 			stdio: 'inherit'
 		});
+
+		info(``);
+		highlight(`Cleaning up your project...`);
+		info(``);
+	
+		// format the files
+		await system.spawn(`cd ${projectName} && ${packageManager} run format`, {
+			shell: true,
+			stdio: 'inherit'
+		});
 	}
-
-	info(``);
-	highlight(`Cleaning up your project...`);
-
-	// format the files
-	await system.spawn(`cd ${projectName} && ${packageManager} run format`, {
-		shell: true,
-		stdio: 'inherit'
-	});
 
 	if (!options.noGit && !flags.noGit) {
 		info(``);


### PR DESCRIPTION
- Add extra comma to fix the `json` format
- Don't run `format` with `noInstall`

Fixes: #41 & #36