### PR TITLE
fix(run-ignite): no longer need the version check

### DIFF
--- a/cli/src/utilities/runIgnite.ts
+++ b/cli/src/utilities/runIgnite.ts
@@ -29,11 +29,9 @@ export async function runIgnite(toolbox: Toolbox) {
 	// right now Ignite requires PascalCase for the project name
 	// unsure why, will ask the team and then probably fix it upstream
 	const formattedName = pascalCase(projectName);
-	// bun is only available for @next version at the moment
-	const igniteVersion = packageManager === 'bun' ? 'next' : 'latest';
 
 	success('Running Ignite CLI to create an opinionated stack...');
-	await system.spawn(`npx ignite-cli@${igniteVersion} new ${formattedName} --packager=${packageManager} --yes`, {
+	await system.spawn(`npx ignite-cli@$latest new ${formattedName} --packager=${packageManager} --yes`, {
 		shell: true,
 		stdio: 'inherit'
 	});


### PR DESCRIPTION
## Description
- Ignite v9 was released, so this removes the version switch logic that was due to bun support not being available in v8