### PR TITLE
fixed format error while running format script

### DIFF
--- a/cli/src/templates/base/package.json.ejs
+++ b/cli/src/templates/base/package.json.ejs
@@ -4,9 +4,9 @@
   "scripts": {
     "android": "expo start --android",
 	<% if (props.packageManager === "bun") { %>
-		"format": "bun run eslint **/*.{js,jsx,ts,tsx} --fix && bun run prettier **/*.{js,jsx,ts,tsx,json} --write",
+		"format": "bun run eslint \"**/*.{js,jsx,ts,tsx}\" --fix && prettier \"**/*.{js,jsx,ts,tsx,json}\" --write",
 	<% } else { %>
-    	"format": "eslint '**/*.{js,jsx,ts,tsx}' --fix && prettier '**/*.{js,jsx,ts,tsx,json}' --write",
+    	"format": "eslint \"**/*.{js,jsx,ts,tsx}\" --fix && prettier \"**/*.{js,jsx,ts,tsx,json}\" --write",
 	<% } %>
     "ios": "expo start --ios",
     "start": "expo start",

--- a/cli/src/templates/base/package.json.ejs
+++ b/cli/src/templates/base/package.json.ejs
@@ -4,7 +4,7 @@
   "scripts": {
     "android": "expo start --android",
 	<% if (props.packageManager === "bun") { %>
-		"format": "bun run eslint '**/*.{js,jsx,ts,tsx}' --fix && bun run prettier '**/*.{js,jsx,ts,tsx,json}' --write",
+		"format": "bun run eslint **/*.{js,jsx,ts,tsx} --fix && bun run prettier **/*.{js,jsx,ts,tsx,json} --write",
 	<% } else { %>
     	"format": "eslint '**/*.{js,jsx,ts,tsx}' --fix && prettier '**/*.{js,jsx,ts,tsx,json}' --write",
 	<% } %>


### PR DESCRIPTION
fixes #73 
fixed `No files matching the pattern "'**/*.{js,jsx,ts,tsx}'" were found.` error
