### PR TITLE
chore: fix .changeset/config.json ignore

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,6 +9,6 @@
   "access": "public",
   "baseBranch": "main",
   "fixed": [["create-expo-stack"]],
-  "ignore": ["create-expo-stack-web"]
+  "ignore": ["create-expo-stack-docs", "create-expo-stack-landing"]
   
 }

--- a/.changeset/tiny-penguins-join.md
+++ b/.changeset/tiny-penguins-join.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+fix .changeset/config.json ignore to refer to (valid) non-cli subprojects


### PR DESCRIPTION
fix .changeset/config.json ignore to refer to (valid) non-cli subprojects

This fixes the ability to run `bunx changeset`.

Thanks to @ernestoresende for providing the fix/instructions here!