### PR TITLE
chore(changeset): baseBranch should the branch that PRs are based on / created against

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,7 @@
   "commit": false,
   "updateInternalDependencies": "patch",
   "access": "public",
-  "baseBranch": "main",
+  "baseBranch": "beta",
   "fixed": [["create-expo-stack"]],
   "ignore": ["create-expo-stack-docs", "create-expo-stack-landing"]
   


### PR DESCRIPTION
This fixes an issue where users who just cloned the repo, and thus don't have the main branch locally (i.e. because the default branch is `beta`), are unable to create a changeset.

It's also the recommended approach according to the `changeset` documentation, which [Ernesto notes below](https://github.com/danstepanov/create-expo-stack/pull/79#issuecomment-1827605221)

Since this modifies the changeset configuration's baseBranch, it also affects the deployment process as outlined under the "Changes fro the Maintainer" heading.

## Changes for the Contributor

Before, contributors would need to have the `main` branch available locally in order to run `bunx changeset`. This wasn't automatic, because `main` is not the default branch.

After this PR, contributors should already have the `beta` branch available locally because it's the default branch (currently).
- **_In the future_**, if/when we change the `beta` branch name, an issue like this would occur again (for people who forked or cloned the project before the default branch name changed). To fix this, contributors who forked or cloned **before** the name change would need to update their fork (to set the new default branch) and checkout that branch locally.

## Changes for the Maintainer

As mentioned, I believe this changes the deployment process slightly, since changeset will autogenerate PRs against `beta` rather than `main` now. My understanding of the before/after:

### Before

1. Merge changes from `beta` (either with a PR or manually) to `main` when you want to do a release.
1. The `changeset` GitHub Actions will create (or update) a PR against `main`.
1. A maintainer merges that PR.
1. In order to have the changesets _removed_ from `.changeset/` (and the automated package.json version bump _present_) in the `beta` branch, the maintainer merges/pushes from `main` back into `beta` to get it caught back up. This should hopefully be a fast-forward merge (i.e. no merge commit) to keep the commit history clean.

### After

Differences from "Before" are in **bold**:

1. Merge changes from `beta` (either with a PR or manually) to `main` when you want to do a release.
1. The `changeset` GitHub Actions will create (or update) a PR against **`beta`**.
1. A maintainer merges that PR.
1. In order to have the changesets _removed_ from `.changeset/` (and the automated package.json version bump _present_) in the **`main`** branch, the maintainer merges/pushes from **`beta`** back into **`main`** to get it caught back up. This should hopefully be a fast-forward merge (i.e. no merge commit) to keep the commit history clean.

### The Differences

Compared to before, now:

1. After merging to `main`, the `changeset` GitHub Actions autogenerates the PR against `beta`, not `main`.
1. In the last step, the maintainer is updating `main` to have the changes that were just merged into `beta` -- not the other way around. 
