### PR TITLE
feat(cli): adds `--importAlias`

### DIFF
--- a/.changeset/famous-panthers-press.md
+++ b/.changeset/famous-panthers-press.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': minor
+---
+
+Adds `--importAlias` to enable TS path aliases

--- a/cli/src/commands/create-expo-stack.ts
+++ b/cli/src/commands/create-expo-stack.ts
@@ -70,6 +70,14 @@ const command: GluegunCommand = {
 				cliResults.flags.noInstall = options.noInstall;
 				cliResults.flags.noGit = options.noGit;
 
+				// Validate import alias string forward slash and asterisk
+				if (typeof options.importAlias === 'string') {
+					if (!options.importAlias.endsWith('/*')) {
+						throw new Error('Import alias must end in `/*`, for example: `@/*` or `~/`');
+					}
+				}
+				cliResults.flags.importAlias = options.importAlias;
+
 				if (!(useDefault || optionsPassedIn || skipCLI || useBlankTypescript)) {
 					//  Run the CLI to prompt the user for input
 					cliResults = await runCLI(toolbox);
@@ -179,6 +187,10 @@ const command: GluegunCommand = {
 					// Check if the user wants to skip initializing git
 					if (cliResults.flags.noGit) {
 						script += '--noGit ';
+					}
+
+					if (cliResults.flags.importAlias) {
+						script += '--importAlias ';
 					}
 
 					// Add the package manager

--- a/cli/src/templates/base/app.json.ejs
+++ b/cli/src/templates/base/app.json.ejs
@@ -13,11 +13,19 @@
       "plugins": ["expo-router"],
       "experiments": {
         "typedRoutes": true
+        <% if (props.flags.importAlias) { %>
+          ,"tsconfigPaths": true
+        <% } %>
       },
     <% } else { %>
       "web": {
         "favicon": "./assets/favicon.png"
       },
+      <% if (props.flags.importAlias) { %>
+        "experiments": {
+          "tsconfigPaths": true
+        },
+      <% } %> 
     <% } %>
     "orientation": "portrait",
     "icon": "./assets/icon.png",

--- a/cli/src/templates/base/tsconfig.json.ejs
+++ b/cli/src/templates/base/tsconfig.json.ejs
@@ -2,6 +2,17 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true
+    <% if (props.flags.importAlias) { %>
+      ,
+    "baseUrl": ".",
+    "paths": {
+      <% if (props.flags.importAlias === true) { %>
+      "~/*": ["src/*"]
+      <% } else { %>
+      "<%= props.flags.importAlias %>": ["src/*"]
+      <% } %>
+    }
+    <% } %>
   <% if (props.navigationPackage?.name === 'expo-router') { %>
   },
   "include": [

--- a/cli/src/utilities/showHelp.ts
+++ b/cli/src/utilities/showHelp.ts
@@ -15,6 +15,7 @@ export function showHelp(info, highlight, warning) {
 	info('        --yarn            Use yarn as the package manager');
 	info('        --pnpm            Use pnpm as the package manager');
 	info('	--bun		  Use bun as the package manager');
+	info('        --importAlias     Enable TS path aliases');
 	info('    -v, --version         Version number');
 	info('    -h, --help            Usage info');
 	info('');

--- a/contributing.md
+++ b/contributing.md
@@ -47,13 +47,15 @@ Install all the workspace dependencies with: `bun install` on the project root.
 To quickly run the documentation website after installing all dependencies:
 
 ```shell
-$ bun dev:docs
+$ cd docs
+$ bun start
 ```
 
 To quickly run the landing page website after installing all dependencies:
 
 ```shell
-$ bun dev:www
+$ cd www
+$ bun start
 ```
 
 <!-- To quickly setup `create-expo-stack` for local testing, you'll need to link a local version to run on your machine: -->

--- a/docs/src/content/docs/en/installation.md
+++ b/docs/src/content/docs/en/installation.md
@@ -9,15 +9,16 @@ npx create-expo-stack@latest
 
 ## Advanced usage
 
-| Option/Flag   | Description                                                             |
-| ------------- | ----------------------------------------------------------------------- |
-| `--npm`       | Selects npm to be your package manager                                  |
-| `--yarn`      | Selects yarn to be your package manager                                 |
-| `--pnpm`      | Selects pnpm to be your package manager                                 |
-| `--bun`       | Selects bun to be your package manager                                  |
-| `--noGit`     | Explicitly tell the CLI to not initialize a new git repo in the project |
-| `--default`   | Bypass the CLI and bootstrap a new create-expo-stack with all options selected     |
-| `--noInstall` | Generate project without installing dependencies                        |
+| Option/Flag     | Description                                                             |
+| --------------  | ----------------------------------------------------------------------- |
+| `--npm`         | Selects npm to be your package manager                                  |
+| `--yarn`        | Selects yarn to be your package manager                                 |
+| `--pnpm`        | Selects pnpm to be your package manager                                 |
+| `--bun`         | Selects bun to be your package manager                                  |
+| `--noGit`       | Explicitly tell the CLI to not initialize a new git repo in the project |
+| `--default`     | Bypass the CLI and bootstrap a new create-expo-stack with all options selected     |
+| `--noInstall`   | Generate project without installing dependencies                        |
+| `--importAlias` | Enable TypeScript path aliases                                          |
 
 ## Example
 The following would scaffold a Create Expo Stack App with pnpm and no git.


### PR DESCRIPTION
## Description
- Closes #17 
- Adds `--importAlias` as a cli switch
- Will utilize default `~/*` mapped to `src` if no specific one is entered
- Can utilize other patterns, such as Expo's default `@/*` for example
- Validation when a string is passed in to make sure the format is correct

## Screenshots

> Example of having a `Header` component live in `src/components/Header.tsx` and being imported via path alias: `import { Header } from '~/components/Header';`

<img width="1584" alt="image" src="https://github.com/danstepanov/create-expo-stack/assets/374022/5b152f5a-ff06-4c04-9d10-81b63a58957f">
