### PR TITLE
docs: add newline

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -30,6 +30,7 @@ To get started, use npx to run the CLI tool. You will be prompted to opt into th
 `npx create-expo-stack@latest`
 
 <img src="https://github.com/danstepanov/create-expo-stack/assets/5482800/e709dd66-cb9b-463c-91f9-b842bb80585c" />
+
 ## Tech Stack for the templates
 
 Currently, all of the [templates](https://github.com/danstepanov/create-expo-stack/tree/main/cli/src/templates) use the same versions of the following libraries. Not all of the templates include all of the libraries, but they are all available for use.


### PR DESCRIPTION
Add a newline to the README. The header text was not formatted correctly