### PR TITLE
Fix incorrect type definition on DrawerNavigator template

### DIFF
--- a/.changeset/healthy-keys-help.md
+++ b/.changeset/healthy-keys-help.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+Fix mismatching RootStackParamList type definition for DrawerNavigator

--- a/cli/src/templates/packages/react-navigation/navigation/index.tsx.ejs
+++ b/cli/src/templates/packages/react-navigation/navigation/index.tsx.ejs
@@ -126,7 +126,7 @@
 		import DrawerNavigator from "./drawer-navigator";
 	
 		export type RootStackParamList = {
-			TabNavigator: undefined;
+			DrawerNavigator: undefined;
 			Modal: undefined;
 		};
 	


### PR DESCRIPTION
The Drawer Navigator template had a name mismatch in the RootStackParamList that caused TypeScript error on a newly created project using drawer navigator
I've replaced `TabNavigator` with `DrawerNavigator` in the type definition.
PS. This is my first contribution, please let me know if I forgot to do something