### PR TITLE
refactor(commands): get projectName before branching off into CLI

### DIFF
--- a/.changeset/fast-fans-breathe.md
+++ b/.changeset/fast-fans-breathe.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+refactor(commands): get projectName before branching off into CLI

--- a/cli/src/utilities/runCLI.ts
+++ b/cli/src/utilities/runCLI.ts
@@ -1,13 +1,11 @@
 import { Toolbox } from 'gluegun/build/types/domain/toolbox';
 
-import { DEFAULT_APP_NAME, defaultOptions } from '../constants';
+import { defaultOptions } from '../constants';
 import { CliResults, NavigationTypes, PackageManager } from '../types';
-import { validateProjectName } from './validateProjectName';
 
-export async function runCLI(toolbox: Toolbox): Promise<CliResults> {
+export async function runCLI(toolbox: Toolbox, projectName: string): Promise<CliResults> {
 	const {
-		filesystem: { exists, removeAsync },
-		parameters: { first, options },
+		parameters: { options },
 		print: { success },
 		prompt
 	} = toolbox;
@@ -15,26 +13,9 @@ export async function runCLI(toolbox: Toolbox): Promise<CliResults> {
 	// Set the default options
 	const cliResults = defaultOptions;
 
-	// Set the app name if it was passed in via the initial command
-	if (first) {
-		cliResults.projectName = first;
-	} else {
-		const askName = {
-			type: 'input',
-			name: 'name',
-			message: `What do you want to name your project? (${DEFAULT_APP_NAME})`
-		};
-		const { name } = await prompt.ask(askName);
-		cliResults.projectName = name || DEFAULT_APP_NAME;
-		const { projectName } = cliResults;
-
-		// Check if the directory already exists
-		if (options.overwrite) {
-			cliResults.flags.overwrite = true;
-		} else {
-			await validateProjectName(exists, removeAsync, prompt, projectName);
-		}
-	}
+	// Project name already validated, just set cliResults
+	cliResults.projectName = projectName;
+	cliResults.flags.overwrite = !!options.overwrite; 
 
 	// Clear default packages
 	cliResults.packages = [];

--- a/cli/src/utilities/runIgnite.ts
+++ b/cli/src/utilities/runIgnite.ts
@@ -1,38 +1,17 @@
 import { Toolbox } from 'gluegun/build/types/domain/toolbox';
-import { DEFAULT_APP_NAME } from '../constants';
 import { getPackageManager } from './getPackageManager';
 import { CliResults } from '../types';
 
-export async function runIgnite(toolbox: Toolbox, cliResults: CliResults) {
+export async function runIgnite(toolbox: Toolbox, projectName: string, cliResults: CliResults) {
 	const {
-		parameters: { first },
 		print: { success },
-		prompt: { ask },
 		system,
-		strings: { pascalCase }
 	} = toolbox;
 
-	let projectName;
-	if (!first) {
-		const askName = {
-			type: 'input',
-			name: 'name',
-			message: `What do you want to name your project? (${DEFAULT_APP_NAME})`
-		};
-		const { name } = await ask(askName);
-		// if name is undefined or empty string, use default name
-		projectName = name || DEFAULT_APP_NAME;
-	} else {
-		projectName = first;
-	}
-
 	const packageManager = getPackageManager(toolbox, cliResults);
-	// right now Ignite requires PascalCase for the project name
-	// unsure why, will ask the team and then probably fix it upstream
-	const formattedName = pascalCase(projectName);
 
 	success('Running Ignite CLI to create an opinionated stack...');
-	await system.spawn(`npx ignite-cli@$latest new ${formattedName} --packager=${packageManager} --yes`, {
+	await system.spawn(`npx ignite-cli@$latest new ${projectName} --packager=${packageManager} --yes`, {
 		shell: true,
 		stdio: 'inherit'
 	});


### PR DESCRIPTION
This refactor lays the groundwork for deleting the project folder if any error occurs while the CLI is running. It does this by determining & finalizing the project name before doing anything else within the command.

Two instances of asking the user and/or checking arguments for the project name have been "hoisted up" from `cli/src/utilities/runCLI` and `cli/src/utilities/runIgnite` into `cli/src/commands/create-expo-stack`, where we can now use the `projectName` in the last error handler for any purposes (such as deleting the generated project folder).