### PR TITLE
added .env to .gitignore when firebase or supabase is used

### DIFF
--- a/.changeset/shy-drinks-sneeze.md
+++ b/.changeset/shy-drinks-sneeze.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+added .env to .gitignore when firebase or supabase is used

--- a/cli/src/templates/base/.gitignore.ejs
+++ b/cli/src/templates/base/.gitignore.ejs
@@ -13,6 +13,8 @@ web-build/
 expo-env.d.ts<% } %>
 <% if (props.stylingPackage?.name === "tamagui") { %># tamagui
 .tamagui/<% } %>
+<% if ((props.authenticationPackage?.name === "supabase") || (props.authenticationPackage?.name === "firebase")) { %># firebase/supabase
+.env<% } %>
 
 # macOS
 .DS_Store


### PR DESCRIPTION
the .env file is created when firebase or supabase are used but it wasn't added to the .gitignore. This PR fixes that.