### PR TITLE
feat(commands): exit unsuccessfully with error, better error messages

### DIFF
--- a/.changeset/small-penguins-dance.md
+++ b/.changeset/small-penguins-dance.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+feat: re-throw error on exit to indicate execution failure, show error diagnostics

--- a/cli/src/commands/create-expo-stack.ts
+++ b/cli/src/commands/create-expo-stack.ts
@@ -253,11 +253,13 @@ const command: GluegunCommand = {
 			}
 		} catch (error) {
 			// await removeAsync(cliResults.projectName);
-			info(`Oops, something went wrong while creating your project 😢`);
-			info(`\n${error.message ? error.message : error}`);
+			info(`\nOops, something went wrong while creating your project 😢`);
 			info(
 				`\nIf this was unexpected, please open an issue: https://github.com/danstepanov/create-expo-stack#reporting-bugs--feedback`
 			);
+			info('');
+
+			throw error;
 		}
 	}
 };


### PR DESCRIPTION
## Summary

Before, the CLI would exit with a status code of `0`, even if something went wrong, because we were catching any errors, logging a help message, and then letting the `src/commands/create-expo-stack.js` just return normally.

This meant that when a failure was caught and the command exited, things like tests wouldn't be aware that there was a failure at all, and would assume the test ran successfully.

This fixes the tests from passing when they shouldn't, and it also provides much better error diagnostics to the user for reporting purposes.

Here's a demonstration what happens when the CLI exits due to an error (specifically reproducing #136) before and after this change. Notice that my `%` zsh prompt is red in the "After", indicating the command failed, and the better diagnostic info + stack trace provided.

### Before

![Screen Shot 2023-12-20 at 2 27 55 PM](https://github.com/danstepanov/create-expo-stack/assets/2035492/a3f6f209-ad75-47e2-914e-a99f467a64c5)

### After

![Screen Shot 2023-12-20 at 2 27 14 PM](https://github.com/danstepanov/create-expo-stack/assets/2035492/0a0dc10b-a9ed-4837-a42a-dca5331da36d)
