### PR TITLE
fix: stall in validateProjectName when non-interactive, unexpected exit when interactive

### DIFF
--- a/.changeset/little-years-design.md
+++ b/.changeset/little-years-design.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+fix: prompt/interaction causes immediate failure/exit after existsAsync check

--- a/.changeset/silver-ears-lie.md
+++ b/.changeset/silver-ears-lie.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+fix: do not ask to remove existing directory when non-interactive

--- a/cli/src/commands/create-expo-stack.ts
+++ b/cli/src/commands/create-expo-stack.ts
@@ -21,7 +21,7 @@ const command: GluegunCommand = {
 	description: 'Create a new Expo project',
 	run: async (toolbox) => {
 		const {
-			filesystem: { existsAsync, removeAsync },
+			filesystem: { exists, removeAsync },
 			parameters: { first, options },
 			print: { info, highlight, warning },
 			prompt
@@ -171,7 +171,7 @@ const command: GluegunCommand = {
 				}
 
 				// Validate the project name
-				await validateProjectName(existsAsync, removeAsync, prompt, cliResults.projectName);
+				await validateProjectName(exists, removeAsync, prompt, cliResults.projectName);
 
 				// By this point, all cliResults should be set
 				info('');

--- a/cli/src/commands/create-expo-stack.ts
+++ b/cli/src/commands/create-expo-stack.ts
@@ -170,8 +170,13 @@ const command: GluegunCommand = {
 					cliResults.projectName = first;
 				}
 
-				// Validate the project name
-				await validateProjectName(exists, removeAsync, prompt, cliResults.projectName);
+				// Validate the project name; we may or may not be interactive, so conditionally pass in prompt
+				await validateProjectName(
+					exists,
+					removeAsync,
+					!(useDefault || optionsPassedIn || skipCLI || useBlankTypescript) ? prompt : null,
+					cliResults.projectName
+				);
 
 				// By this point, all cliResults should be set
 				info('');

--- a/cli/src/utilities/runCLI.ts
+++ b/cli/src/utilities/runCLI.ts
@@ -6,7 +6,7 @@ import { validateProjectName } from './validateProjectName';
 
 export async function runCLI(toolbox: Toolbox): Promise<CliResults> {
 	const {
-		filesystem: { existsAsync, removeAsync },
+		filesystem: { exists, removeAsync },
 		parameters: { first },
 		print: { success },
 		prompt
@@ -28,7 +28,7 @@ export async function runCLI(toolbox: Toolbox): Promise<CliResults> {
 		cliResults.projectName = name || DEFAULT_APP_NAME;
 		const { projectName } = cliResults;
 		// Check if the directory already exists
-		await validateProjectName(existsAsync, removeAsync, prompt, projectName);
+		await validateProjectName(exists, removeAsync, prompt, projectName);
 	}
 
 	// Clear default packages

--- a/cli/src/utilities/validateProjectName.ts
+++ b/cli/src/utilities/validateProjectName.ts
@@ -1,8 +1,8 @@
 import { ExistsResult } from 'fs-jetpack/types';
 import { GluegunPrompt } from 'gluegun';
 
-export async function validateProjectName(existsAsync: (path: string) => Promise<ExistsResult>, removeAsync: (path?: string) => Promise<void>, prompt: GluegunPrompt, projectName: string) {
-	if (await existsAsync(projectName)) {
+export async function validateProjectName(exists: (path: string) => ExistsResult, removeAsync: (path?: string) => Promise<void>, prompt: GluegunPrompt, projectName: string): Promise<void> {
+	if (exists(projectName)) {
 		const confirmDelete = await prompt.ask([
 		  {
 			type: 'confirm',

--- a/cli/src/utilities/validateProjectName.ts
+++ b/cli/src/utilities/validateProjectName.ts
@@ -1,8 +1,12 @@
 import { ExistsResult } from 'fs-jetpack/types';
 import { GluegunPrompt } from 'gluegun';
 
-export async function validateProjectName(exists: (path: string) => ExistsResult, removeAsync: (path?: string) => Promise<void>, prompt: GluegunPrompt, projectName: string): Promise<void> {
-	if (exists(projectName)) {
+export async function validateProjectName(exists: (path: string) => ExistsResult, removeAsync: (path?: string) => Promise<void>, prompt: GluegunPrompt | null, projectName: string): Promise<void> {
+	if (!exists(projectName)) {
+		return;
+	}
+
+	if (prompt != null) {
 		const confirmDelete = await prompt.ask([
 		  {
 			type: 'confirm',
@@ -10,12 +14,12 @@ export async function validateProjectName(exists: (path: string) => ExistsResult
 			message: `A folder with the name '${projectName}' already exists. Do you want to delete it?`
 		  },
 		]);
-  
+
 		if (confirmDelete.delete) {
 		  await removeAsync(projectName);
-		  console.log(`Deleted existing directory: ${projectName}`);
-		} else {
-		  throw new Error(`Exiting, a project with the name '${projectName}' already exists.`);
+		  return void console.log(`Deleted existing directory: ${projectName}`);
 		}
 	  }
+
+	throw new Error(`A project with the name '${projectName}' already exists.`);
 }


### PR DESCRIPTION
Two fixes:

- [x] When running in non-interactive mode (e.g. when running tests or providing parameters), validateProjectName was prompting the user to delete existing folders, which causes the process to stall. Update to only ask the user if we're running interactively, otherwise exit with an error.
- [x] On Linux and while running with an absolute file path (which we do in the tests), the interactive mode was failing immediately if the "delete existing folder" wasn't the last prompt (i.e. failing if the project name wasn't passed to the CLI). @danstepanov confirmed this isn't happening on macOS with an absolute file path. I have found a workaround by using the synchronous version of `exists`.
  - related: #136.

### Before

Addressing the first bullet: here's the command stalling while running non-interactive (using `<$(mktemp)` to simulate non-interactive; using `</dev/null` crashes Bun); note the several empty newlines from pressing enter (to demonstrate that the shell is non-interactive / not accepting my input):

![Screen Shot 2023-12-20 at 3 52 01 PM](https://github.com/danstepanov/create-expo-stack/assets/2035492/62d257f8-cd1b-4344-9e08-e506eec3525f)

Addressing the second bullet: here's running the command twice, first without an existing `test/` and the second with one, on Linux; notice that I am not exiting the program, it just exits immediately upon the second prompt, i.e. the prompt immediately after `existsAsync`.

![Screen Shot 2023-12-20 at 3 42 49 PM](https://github.com/danstepanov/create-expo-stack/assets/2035492/ec0ab0ef-6a9a-4089-9c58-2cf6a8235b5a)

### After

If the shell is non-interactive, we throw an error:

![Screen Shot 2023-12-20 at 3 35 51 PM](https://github.com/danstepanov/create-expo-stack/assets/2035492/6a0887cb-6d97-488c-ba4e-fd6292a8e111)
