### PR TITLE
Fix test issues related to overwriting files

### DIFF
--- a/.changeset/light-bees-rush.md
+++ b/.changeset/light-bees-rush.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+feat: add --overwrite flag to ignore an existing directory

--- a/cli/__tests__/cli-integration.test.ts
+++ b/cli/__tests__/cli-integration.test.ts
@@ -5,7 +5,7 @@ import { version } from '../package.json';
 import { test, expect } from 'bun:test';
 import * as path from 'node:path';
 
-const cli = async (cmd) => system.run(`bun run ` + path.join('./', `bin`, `create-expo-stack.js`) + ` ${cmd}`);
+const cli = async (cmd) => system.run(`bun run ` + path.join('./', `bin`, `create-expo-stack.js`) + ` ${cmd} --overwrite`);
 
 // Run tests for each package manager
 const packageManagers = [`npm`, `yarn`, `pnpm`, `bun`];

--- a/cli/__tests__/cli-integration.test.ts
+++ b/cli/__tests__/cli-integration.test.ts
@@ -1,12 +1,11 @@
-import { system, filesystem } from 'gluegun';
+import { system } from 'gluegun';
 
 import { version } from '../package.json';
 
 import { test, expect } from 'bun:test';
+import * as path from 'node:path';
 
-const src = filesystem.path(__dirname, `..`);
-
-const cli = async (cmd) => system.run(`bun run ` + filesystem.path(src, `bin`, `create-expo-stack.js`) + ` ${cmd}`);
+const cli = async (cmd) => system.run(`bun run ` + path.join('./', `bin`, `create-expo-stack.js`) + ` ${cmd}`);
 
 // Run tests for each package manager
 const packageManagers = [`npm`, `yarn`, `pnpm`, `bun`];

--- a/cli/src/commands/create-expo-stack.ts
+++ b/cli/src/commands/create-expo-stack.ts
@@ -171,12 +171,17 @@ const command: GluegunCommand = {
 				}
 
 				// Validate the project name; we may or may not be interactive, so conditionally pass in prompt
-				await validateProjectName(
-					exists,
-					removeAsync,
-					!(useDefault || optionsPassedIn || skipCLI || useBlankTypescript) ? prompt : null,
-					cliResults.projectName
-				);
+				// Ignore the existing folder if the overwrite option is passed in.
+				if (options.overwrite) {
+					cliResults.flags.overwrite = true;
+				} else {
+					await validateProjectName(
+						exists,
+						removeAsync,
+						!(useDefault || optionsPassedIn || skipCLI || useBlankTypescript) ? prompt : null,
+						cliResults.projectName
+					);
+				}
 
 				// By this point, all cliResults should be set
 				info('');

--- a/cli/src/constants.ts
+++ b/cli/src/constants.ts
@@ -10,6 +10,7 @@ export const defaultOptions: CliResults = {
 	flags: {
 		noGit: false,
 		noInstall: false,
+		overwrite: false,
 		importAlias: '~/',
 		packageManager: undefined
 	}

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -2,6 +2,7 @@
 export interface CliFlags {
 	noGit: boolean;
 	noInstall: boolean;
+	overwrite: boolean;
 	importAlias: string;
 	packageManager: PackageManager;
 }

--- a/cli/src/utilities/runCLI.ts
+++ b/cli/src/utilities/runCLI.ts
@@ -7,7 +7,7 @@ import { validateProjectName } from './validateProjectName';
 export async function runCLI(toolbox: Toolbox): Promise<CliResults> {
 	const {
 		filesystem: { exists, removeAsync },
-		parameters: { first },
+		parameters: { first, options },
 		print: { success },
 		prompt
 	} = toolbox;
@@ -27,8 +27,13 @@ export async function runCLI(toolbox: Toolbox): Promise<CliResults> {
 		const { name } = await prompt.ask(askName);
 		cliResults.projectName = name || DEFAULT_APP_NAME;
 		const { projectName } = cliResults;
+
 		// Check if the directory already exists
-		await validateProjectName(exists, removeAsync, prompt, projectName);
+		if (options.overwrite) {
+			cliResults.flags.overwrite = true;
+		} else {
+			await validateProjectName(exists, removeAsync, prompt, projectName);
+		}
 	}
 
 	// Clear default packages

--- a/cli/src/utilities/showHelp.ts
+++ b/cli/src/utilities/showHelp.ts
@@ -10,6 +10,7 @@ export function showHelp(info, highlight, warning) {
 	info('    -d, --default         Use the default options for creating a project');
 	info('        --noInstall       Skip installing npm packages or CocoaPods');
 	info('        --noGit           Skip initializing a git repository');
+	info('        --overwrite       Skip checks for an existing project directory');
 	info('        --blank           Use the blank typescript template');
 	info('        --npm             Use npm as the package manager');
 	info('        --yarn            Use yarn as the package manager');


### PR DESCRIPTION
## Summary

Since the addition of a prompt and/or error if the project directory already exists, tests are failing after the first project generation (or after previously running tests) because the test project directory already exists.

- [x] Add an `--overwrite` flag that opts out of executing `validateProjectName`, reverting to the old behavior of overwriting the contents of the existing directory.
- [x] Fixes #136 (in terms of the tests) by running the tests using relative file paths instead of absolute.

## Before

Tests are failing, either due to #136 or the fact that the directory already exists.

## After

Tests are running (but still taking a while and may timeout in CI)