### PR TITLE
fix(commands): successfully exit when user cancels

### DIFF
--- a/.changeset/loud-cheetahs-unite.md
+++ b/.changeset/loud-cheetahs-unite.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+fix: successfully exit interactive CLI when user cancels/exits with interrupt

--- a/cli/src/commands/create-expo-stack.ts
+++ b/cli/src/commands/create-expo-stack.ts
@@ -23,8 +23,8 @@ const command: GluegunCommand = {
 		const {
 			filesystem: { exists, removeAsync },
 			parameters: { first, options },
-			print: { info, highlight, warning },
-			prompt
+			print: { info, highlight, success, warning },
+			prompt,
 		} = toolbox;
 
 		if (options.help || options.h) {
@@ -262,6 +262,11 @@ const command: GluegunCommand = {
 				await printOutput(cliResults, formattedFiles, toolbox);
 			}
 		} catch (error) {
+			if (error === "") {
+				// user cancelled/exited the interactive CLI
+				return void success(`\nCancelled... 👋 `);
+			}
+
 			// await removeAsync(cliResults.projectName);
 			info(`\nOops, something went wrong while creating your project 😢`);
 			info(


### PR DESCRIPTION
## Summary

An exit with a ^C, ^D, etc. interrupt should exit successfully during the interactive CLI.

### Before

Exiting during the interactive CLI via ^C would output just `error` in red text along with the URL to submit issues (before #137), and now it outputs the full stack trace to the interrupt handler since the aforementioned PR was merged.

![Screen Shot 2023-12-20 at 5 15 39 PM](https://github.com/danstepanov/create-expo-stack/assets/2035492/551e3f21-4624-417d-a919-c6d2fdc1744d)

### After

Catch the error as before but don't go through the normal error handling, instead wave goodbye:

![Screen Shot 2023-12-20 at 5 15 01 PM](https://github.com/danstepanov/create-expo-stack/assets/2035492/a0788d58-aea3-45f6-a2ec-ecd5c6dd7d54)

Exiting the command during the actual build/running phase still results in an error (and still no error diagnostics), as you'd expect:

![Screen Shot 2023-12-20 at 5 16 18 PM](https://github.com/danstepanov/create-expo-stack/assets/2035492/6fe69b32-1ac1-4bef-9c9a-5e3b61c7dd40)