### PR TITLE
fix(expo-router): yarn hot refresh

### DIFF
--- a/.changeset/shiny-eggs-peel.md
+++ b/.changeset/shiny-eggs-peel.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+Fixes hot refresh when using yarn with expo-router

--- a/cli/src/templates/base/package.json.ejs
+++ b/cli/src/templates/base/package.json.ejs
@@ -97,13 +97,9 @@
   },
   <% if (props.navigationPackage?.name === 'expo-router') { %>
     "resolutions": {
-      "metro": "0.76.0",
-      "metro-resolver": "0.76.0",
       "react-refresh": "~0.14.0"
     },
     "overrides": {
-      "metro": "0.76.0",
-      "metro-resolver": "0.76.0",
       "react-refresh": "~0.14.0"
     },
   <% } else { %>


### PR DESCRIPTION
## Overview
- Closes #143 
- Reports of yarn not working with `expo-router` templates specfically, `npm` and `bun` however were working fine.
- Related to locking the metro versions via resolutinos/overrides, taking that restriction off