### PR TITLE
[cli] Support kebab case for cli flags

### DIFF
--- a/cli/__tests__/cli-integration.test.ts
+++ b/cli/__tests__/cli-integration.test.ts
@@ -34,14 +34,17 @@ for (const packageManager of packageManagers) {
     expect(output).toContain(packageManager);
   });
 
-  test(`generates a project with react-navigation stack and noGit with ${packageManager}`, async () => {
-    const output = await cli(`myTestProject --react-navigation --stack --noGit --${packageManager}`);
+  test(`generates a project with react-navigation stack and no-git with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --react-navigation --stack --no-git --${packageManager}`);
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
   });
 
-  test(`generates a project with react-navigation stack and noGit and noInstall with ${packageManager}`, async () => {
-    const output = await cli(`myTestProject --react-navigation --stack --noGit --noInstall --${packageManager}`);
+  test(`generates a project with react-navigation stack and no-git and no-install with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --react-navigation --stack --no-git --no-install --${packageManager}`);
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
+    expect(output).not.toContain('Installing dependencies');
   });
 
   // --react-navigation stack nativewind
@@ -50,16 +53,19 @@ for (const packageManager of packageManagers) {
     expect(output).toContain(packageManager);
   });
 
-  test(`generates a project with react-navigation stack and nativewind and noGit with ${packageManager}`, async () => {
-    const output = await cli(`myTestProject --react-navigation --stack --nativewind --noGit --${packageManager}`);
+  test(`generates a project with react-navigation stack and nativewind and no-git with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --react-navigation --stack --nativewind --no-git --${packageManager}`);
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
   });
 
-  test(`generates a project with react-navigation stack and nativewind and noGit and noInstall with ${packageManager}`, async () => {
+  test(`generates a project with react-navigation stack and nativewind and no-git and no-install with ${packageManager}`, async () => {
     const output = await cli(
-      `myTestProject --react-navigation --stack --nativewind --noGit --noInstall --${packageManager}`
+      `myTestProject --react-navigation --stack --nativewind --no-git --no-install --${packageManager}`
     );
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
+    expect(output).not.toContain('Installing dependencies');
   });
 
   // --react-navigation stack tamagui
@@ -68,16 +74,19 @@ for (const packageManager of packageManagers) {
     expect(output).toContain(packageManager);
   });
 
-  test(`generates a project with react-navigation stack and tamagui and noGit with ${packageManager}`, async () => {
-    const output = await cli(`myTestProject --react-navigation --stack --tamagui --noGit --${packageManager}`);
+  test(`generates a project with react-navigation stack and tamagui and no-git with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --react-navigation --stack --tamagui --no-git --${packageManager}`);
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
   });
 
-  test(`generates a project with react-navigation stack and tamagui and noGit and noInstall with ${packageManager}`, async () => {
+  test(`generates a project with react-navigation stack and tamagui and no-git and no-install with ${packageManager}`, async () => {
     const output = await cli(
-      `myTestProject --react-navigation --stack --tamagui --noGit --noInstall --${packageManager}`
+      `myTestProject --react-navigation --stack --tamagui --no-git --no-install --${packageManager}`
     );
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
+    expect(output).not.toContain('Installing dependencies');
   });
 
   // --react-navigation tabs
@@ -86,14 +95,16 @@ for (const packageManager of packageManagers) {
     expect(output).toContain(packageManager);
   });
 
-  test(`generates a project with react-navigation tabs and noGit with ${packageManager}`, async () => {
-    const output = await cli(`myTestProject --react-navigation --tabs --noGit --${packageManager}`);
+  test(`generates a project with react-navigation tabs and no-git with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --react-navigation --tabs --no-git --${packageManager}`);
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
   });
 
-  test(`generates a project with react-navigation tabs and noGit and noInstall with ${packageManager}`, async () => {
-    const output = await cli(`myTestProject --react-navigation --tabs --noGit --noInstall --${packageManager}`);
+  test(`generates a project with react-navigation tabs and no-git and no-install with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --react-navigation --tabs --no-git --no-install --${packageManager}`);
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
   });
 
   // --react-navigation tabs nativewind
@@ -102,16 +113,19 @@ for (const packageManager of packageManagers) {
     expect(output).toContain(packageManager);
   });
 
-  test(`generates a project with react-navigation tabs and nativewind and noGit with ${packageManager}`, async () => {
-    const output = await cli(`myTestProject --react-navigation --tabs --nativewind --noGit --${packageManager}`);
+  test(`generates a project with react-navigation tabs and nativewind and no-git with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --react-navigation --tabs --nativewind --no-git --${packageManager}`);
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
   });
 
-  test(`generates a project with react-navigation tabs and nativewind and noGit and noInstall with ${packageManager}`, async () => {
+  test(`generates a project with react-navigation tabs and nativewind and no-git and no-install with ${packageManager}`, async () => {
     const output = await cli(
-      `myTestProject --react-navigation --tabs --nativewind --noGit --noInstall --${packageManager}`
+      `myTestProject --react-navigation --tabs --nativewind --no-git --no-install --${packageManager}`
     );
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
+    expect(output).not.toContain('Installing dependencies');
   });
 
   // --react-navigation tabs tamagui
@@ -120,16 +134,19 @@ for (const packageManager of packageManagers) {
     expect(output).toContain(packageManager);
   });
 
-  test(`generates a project with react-navigation tabs and tamagui and noGit with ${packageManager}`, async () => {
-    const output = await cli(`myTestProject --react-navigation --tabs --tamagui --noGit --${packageManager}`);
+  test(`generates a project with react-navigation tabs and tamagui and no-git with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --react-navigation --tabs --tamagui --no-git --${packageManager}`);
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
   });
 
-  test(`generates a project with react-navigation tabs and tamagui and noGit and noInstall with ${packageManager}`, async () => {
+  test(`generates a project with react-navigation tabs and tamagui and no-git and no-install with ${packageManager}`, async () => {
     const output = await cli(
-      `myTestProject --react-navigation --tabs --tamagui --noGit --noInstall --${packageManager}`
+      `myTestProject --react-navigation --tabs --tamagui --no-git --no-install --${packageManager}`
     );
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
+    expect(output).not.toContain('Installing dependencies');
   });
 
   // --react-navigation drawer
@@ -138,14 +155,16 @@ for (const packageManager of packageManagers) {
     expect(output).toContain(packageManager);
   });
 
-  test(`generates a project with react-navigation drawer and noGit with ${packageManager}`, async () => {
-    const output = await cli(`myTestProject --react-navigation --drawer --noGit --${packageManager}`);
+  test(`generates a project with react-navigation drawer and no-git with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --react-navigation --drawer --no-git --${packageManager}`);
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
   });
 
-  test(`generates a project with react-navigation drawer and noGit and noInstall with ${packageManager}`, async () => {
-    const output = await cli(`myTestProject --react-navigation --drawer --noGit --noInstall --${packageManager}`);
+  test(`generates a project with react-navigation drawer and no-git and no-install with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --react-navigation --drawer --no-git --no-install --${packageManager}`);
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
   });
 
   // --react-navigation drawer nativewind
@@ -154,16 +173,19 @@ for (const packageManager of packageManagers) {
     expect(output).toContain(packageManager);
   });
 
-  test(`generates a project with react-navigation drawer and nativewind and noGit with ${packageManager}`, async () => {
-    const output = await cli(`myTestProject --react-navigation --drawer --nativewind --noGit --${packageManager}`);
+  test(`generates a project with react-navigation drawer and nativewind and no-git with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --react-navigation --drawer --nativewind --no-git --${packageManager}`);
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
   });
 
-  test(`generates a project with react-navigation drawer and nativewind and noGit and noInstall with ${packageManager}`, async () => {
+  test(`generates a project with react-navigation drawer and nativewind and no-git and no-install with ${packageManager}`, async () => {
     const output = await cli(
-      `myTestProject --react-navigation --drawer --nativewind --noGit --noInstall --${packageManager}`
+      `myTestProject --react-navigation --drawer --nativewind --no-git --no-install --${packageManager}`
     );
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
+    expect(output).not.toContain('Installing dependencies');
   });
 
   // --react-navigation drawer tamagui
@@ -172,16 +194,19 @@ for (const packageManager of packageManagers) {
     expect(output).toContain(packageManager);
   });
 
-  test(`generates a project with react-navigation drawer and tamagui and noGit with ${packageManager}`, async () => {
-    const output = await cli(`myTestProject --react-navigation --drawer --tamagui --noGit --${packageManager}`);
+  test(`generates a project with react-navigation drawer and tamagui and no-git with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --react-navigation --drawer --tamagui --no-git --${packageManager}`);
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
   });
 
-  test(`generates a project with react-navigation drawer and tamagui and noGit and noInstall with ${packageManager}`, async () => {
+  test(`generates a project with react-navigation drawer and tamagui and no-git and no-install with ${packageManager}`, async () => {
     const output = await cli(
-      `myTestProject --react-navigation --drawer --tamagui --noGit --noInstall --${packageManager}`
+      `myTestProject --react-navigation --drawer --tamagui --no-git --no-install --${packageManager}`
     );
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
+    expect(output).not.toContain('Installing dependencies');
   });
 
   // --expo-router stack
@@ -190,14 +215,17 @@ for (const packageManager of packageManagers) {
     expect(output).toContain(packageManager);
   });
 
-  test(`generates a project with expo-router stack and noGit with ${packageManager}`, async () => {
-    const output = await cli(`myTestProject --expo-router --stack --noGit --${packageManager}`);
+  test(`generates a project with expo-router stack and no-git with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --expo-router --stack --no-git --${packageManager}`);
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
   });
 
-  test(`generates a project with expo-router stack and noGit and noInstall with ${packageManager}`, async () => {
-    const output = await cli(`myTestProject --expo-router --stack --noGit --noInstall --${packageManager}`);
+  test(`generates a project with expo-router stack and no-git and no-install with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --expo-router --stack --no-git --no-install --${packageManager}`);
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
+    expect(output).not.toContain('Installing dependencies');
   });
 
   // --expo-router stack nativewind
@@ -206,16 +234,19 @@ for (const packageManager of packageManagers) {
     expect(output).toContain(packageManager);
   });
 
-  test(`generates a project with expo-router stack and nativewind and noGit with ${packageManager}`, async () => {
-    const output = await cli(`myTestProject --expo-router --stack --nativewind --noGit --${packageManager}`);
+  test(`generates a project with expo-router stack and nativewind and no-git with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --expo-router --stack --nativewind --no-git --${packageManager}`);
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
   });
 
-  test(`generates a project with expo-router stack and nativewind and noGit and noInstall with ${packageManager}`, async () => {
+  test(`generates a project with expo-router stack and nativewind and no-git and no-install with ${packageManager}`, async () => {
     const output = await cli(
-      `myTestProject --expo-router --stack --nativewind --noGit --noInstall --${packageManager}`
+      `myTestProject --expo-router --stack --nativewind --no-git --no-install --${packageManager}`
     );
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
+    expect(output).not.toContain('Installing dependencies');
   });
 
   // --expo-router stack tamagui
@@ -224,14 +255,17 @@ for (const packageManager of packageManagers) {
     expect(output).toContain(packageManager);
   });
 
-  test(`generates a project with expo-router stack and tamagui and noGit with ${packageManager}`, async () => {
-    const output = await cli(`myTestProject --expo-router --stack --tamagui --noGit --${packageManager}`);
+  test(`generates a project with expo-router stack and tamagui and no-git with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --expo-router --stack --tamagui --no-git --${packageManager}`);
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
   });
 
-  test(`generates a project with expo-router stack and tamagui and noGit and noInstall with ${packageManager}`, async () => {
-    const output = await cli(`myTestProject --expo-router --stack --tamagui --noGit --noInstall --${packageManager}`);
+  test(`generates a project with expo-router stack and tamagui and no-git and no-install with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --expo-router --stack --tamagui --no-git --no-install --${packageManager}`);
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
+    expect(output).not.toContain('Installing dependencies');
   });
 
   // --expo-router tabs
@@ -240,14 +274,17 @@ for (const packageManager of packageManagers) {
     expect(output).toContain(packageManager);
   });
 
-  test(`generates a project with expo-router tabs and noGit with ${packageManager}`, async () => {
-    const output = await cli(`myTestProject --expo-router --tabs --noGit --${packageManager}`);
+  test(`generates a project with expo-router tabs and no-git with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --expo-router --tabs --no-git --${packageManager}`);
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
   });
 
-  test(`generates a project with expo-router tabs and noGit and noInstall with ${packageManager}`, async () => {
-    const output = await cli(`myTestProject --expo-router --tabs --noGit --noInstall --${packageManager}`);
+  test(`generates a project with expo-router tabs and no-git and no-install with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --expo-router --tabs --no-git --no-install --${packageManager}`);
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
+    expect(output).not.toContain('Installing dependencies');
   });
 
   // --expo-router tabs nativewind
@@ -256,14 +293,19 @@ for (const packageManager of packageManagers) {
     expect(output).toContain(packageManager);
   });
 
-  test(`generates a project with expo-router tabs and nativewind and noGit with ${packageManager}`, async () => {
-    const output = await cli(`myTestProject --expo-router --tabs --nativewind --noGit --${packageManager}`);
+  test(`generates a project with expo-router tabs and nativewind and no-git with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --expo-router --tabs --nativewind --no-git --${packageManager}`);
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
   });
 
-  test(`generates a project with expo-router tabs and nativewind and noGit and noInstall with ${packageManager}`, async () => {
-    const output = await cli(`myTestProject --expo-router --tabs --nativewind --noGit --noInstall --${packageManager}`);
+  test(`generates a project with expo-router tabs and nativewind and no-git and no-install with ${packageManager}`, async () => {
+    const output = await cli(
+      `myTestProject --expo-router --tabs --nativewind --no-git --no-install --${packageManager}`
+    );
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
+    expect(output).not.toContain('Installing dependencies');
   });
 
   // --expo-router tabs tamagui
@@ -272,14 +314,17 @@ for (const packageManager of packageManagers) {
     expect(output).toContain(packageManager);
   });
 
-  test(`generates a project with expo-router tabs and tamagui and noGit with ${packageManager}`, async () => {
-    const output = await cli(`myTestProject --expo-router --tabs --tamagui --noGit --${packageManager}`);
+  test(`generates a project with expo-router tabs and tamagui and no-git with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --expo-router --tabs --tamagui --no-git --${packageManager}`);
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
   });
 
-  test(`generates a project with expo-router tabs and tamagui and noGit and noInstall with ${packageManager}`, async () => {
-    const output = await cli(`myTestProject --expo-router --tabs --tamagui --noGit --noInstall --${packageManager}`);
+  test(`generates a project with expo-router tabs and tamagui and no-git and no-install with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --expo-router --tabs --tamagui --no-git --no-install --${packageManager}`);
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
+    expect(output).not.toContain('Installing dependencies');
   });
 
   // --expo-router drawer
@@ -288,14 +333,17 @@ for (const packageManager of packageManagers) {
     expect(output).toContain(packageManager);
   });
 
-  test(`generates a project with expo-router drawer and noGit with ${packageManager}`, async () => {
-    const output = await cli(`myTestProject --expo-router --drawer --noGit --${packageManager}`);
+  test(`generates a project with expo-router drawer and no-git with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --expo-router --drawer --no-git --${packageManager}`);
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
   });
 
-  test(`generates a project with expo-router drawer and noGit and noInstall with ${packageManager}`, async () => {
-    const output = await cli(`myTestProject --expo-router --drawer --noGit --noInstall --${packageManager}`);
+  test(`generates a project with expo-router drawer and no-git and no-install with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --expo-router --drawer --no-git --no-install --${packageManager}`);
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
+    expect(output).not.toContain('Installing dependencies');
   });
 
   // --expo-router drawer nativewind
@@ -304,16 +352,19 @@ for (const packageManager of packageManagers) {
     expect(output).toContain(packageManager);
   });
 
-  test(`generates a project with expo-router drawer and nativewind and noGit with ${packageManager}`, async () => {
-    const output = await cli(`myTestProject --expo-router --drawer --nativewind --noGit --${packageManager}`);
+  test(`generates a project with expo-router drawer and nativewind and no-git with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --expo-router --drawer --nativewind --no-git --${packageManager}`);
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
   });
 
-  test(`generates a project with expo-router drawer and nativewind and noGit and noInstall with ${packageManager}`, async () => {
+  test(`generates a project with expo-router drawer and nativewind and no-git and no-install with ${packageManager}`, async () => {
     const output = await cli(
-      `myTestProject --expo-router --drawer --nativewind --noGit --noInstall --${packageManager}`
+      `myTestProject --expo-router --drawer --nativewind --no-git --no-install --${packageManager}`
     );
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
+    expect(output).not.toContain('Installing dependencies');
   });
 
   // --expo-router drawer tamagui
@@ -322,13 +373,18 @@ for (const packageManager of packageManagers) {
     expect(output).toContain(packageManager);
   });
 
-  test(`generates a project with expo-router drawer and tamagui and noGit with ${packageManager}`, async () => {
-    const output = await cli(`myTestProject --expo-router --drawer --tamagui --noGit --${packageManager}`);
+  test(`generates a project with expo-router drawer and tamagui and no-git with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --expo-router --drawer --tamagui --no-git --${packageManager}`);
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
   });
 
-  test(`generates a project with expo-router drawer and tamagui and noGit and noInstall with ${packageManager}`, async () => {
-    const output = await cli(`myTestProject --expo-router --drawer --tamagui --noGit --noInstall --${packageManager}`);
+  test(`generates a project with expo-router drawer and tamagui and no-git and no-install with ${packageManager}`, async () => {
+    const output = await cli(
+      `myTestProject --expo-router --drawer --tamagui --no-git --no-install --${packageManager}`
+    );
     expect(output).toContain(packageManager);
+    expect(output).not.toContain('Initializing git');
+    expect(output).not.toContain('Installing dependencies');
   });
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -32,7 +32,7 @@
     "publishPublic": "bun run build && npm publish --access public",
     "snapupdate": "jest --updateSnapshot",
     "test:watch": "bun test --watch",
-    "test": "bun test --timeout 25000"
+    "test": "bun test --timeout 30000"
   },
   "prettier": {
     "arrowParens": "always",

--- a/cli/src/commands/create-expo-stack.ts
+++ b/cli/src/commands/create-expo-stack.ts
@@ -35,7 +35,6 @@ const command: GluegunCommand = {
       );
       info('');
     };
-
     if (options.help || options.h) {
       showHelp(info, highlight, warning);
 
@@ -64,7 +63,7 @@ const command: GluegunCommand = {
         !options.exporouter
       ) {
         throw new Error(
-          'You must pass in either --react-navigation or --expo-router if you want to use the --tabs option'
+          'You must pass in either --react-navigation or --expo-router if you want to use the --tabs or --drawer options'
         );
       }
 
@@ -119,8 +118,9 @@ const command: GluegunCommand = {
         await runIgnite(toolbox, cliResults.projectName, cliResults);
       } else {
         // Check if the user wants to not install dependencies and/or not initialize git, update cliResults accordingly
-        cliResults.flags.noInstall = options.noInstall || false;
-        cliResults.flags.noGit = options.noGit || false;
+        cliResults.flags.noInstall =
+          options.noInstall || (typeof options.install === 'boolean' && !options.install) || false;
+        cliResults.flags.noGit = options.noGit || (typeof options.git === 'boolean' && !options.git) || false;
         cliResults.flags.packageManager = options.bun
           ? 'bun'
           : options.pnpm
@@ -137,7 +137,7 @@ const command: GluegunCommand = {
             throw new Error('Import alias must end in `/*`, for example: `@/*` or `~/`');
           }
         }
-        cliResults.flags.importAlias = options.importAlias || true;
+        cliResults.flags.importAlias = options.importAlias || options['import-alias'] || true;
 
         if (!(useDefault || optionsPassedIn || skipCLI || useBlankTypescript)) {
           //  Run the CLI to prompt the user for input
@@ -248,20 +248,22 @@ const command: GluegunCommand = {
 
           // Check if the user wants to skip installing packages
           if (cliResults.flags.noInstall) {
-            script += '--noInstall ';
+            script += '--no-install ';
           }
 
           // Check if the user wants to skip initializing git
           if (cliResults.flags.noGit) {
-            script += '--noGit ';
+            script += '--no-git ';
           }
 
+          // Check if the user wants to overwrite the project directory
+          // TODO: What is this actually doing?
           if (cliResults.flags.importAlias) {
-            script += '--importAlias ';
+            script += '--import-alias ';
           }
 
           // Add the package manager
-          if (cliResults.flags.packageManager) {
+          if (cliResults.flags.packageManager !== 'npm') {
             script += `--${cliResults.flags.packageManager}`;
           }
 


### PR DESCRIPTION
## Description

- Support kebab case for cli flags such as --no-install and --no-git
- Migrate tests to use kebab case, expand test coverage to ensure flags are working properly
- Do not include package manager in output non-interactive script if user is using npm

## Related Issue

#150 

## How Has This Been Tested?

Run tests in cli