### PR TITLE
[infra] fix pre-commit not consuming created changeset

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -12,7 +12,9 @@ if git diff-index --cached HEAD | tr '\t' ' ' | sed 's/^.*[ ]//' | grep '^cli/' 
 	read res < /dev/tty
 	case $res in
 		""|Y|y)
-			bun run changeset < /dev/tty
+			if bun run changeset < /dev/tty; then
+				git add .changeset/*.md
+			fi
 			;;
 	esac
 


### PR DESCRIPTION
## Description

Previously, the pre-commit hook would ask the user if they wanted to created a changeset (i.e. run `bun run changeset`) if any files within `cli/` were modified, but it failed to include the changeset within the commit it ran against.

This resolves the issue and improves DX by automatically adding the newly created changeset to the commit during pre-commit.

## Related Issue

Mentioned in the CES Discord, but I'm not seeing a related issue.

## Motivation and Context

Although the previous behavior was "better than nothing" as it reminded the contributor to create a changeset file for them under the right circumstances, it's a clear flaw and quite misleading for the changeset made during the pre-commit hook to _not_ be included in the commit.

With this change, the creation **and inclusion** of changesets are automatic, avoiding any extra hassle from contributors.

## How Has This Been Tested?

```shell
$ echo "something" >>cli/README.md
$ git commit -a -m "test"
```

A `create mode 100644` for the new changeset appears in the git commit summary (meaning the changeset file was created within the commit), and running a follow up sanity check verifies the changeset isn't hanging around in the staging area or untracked:

```
$ git status
```

## Screenshots (if appropriate):

N/A