### PR TITLE
[cli][docs][www] Add Restyle as a styling solution

### DIFF
--- a/.changeset/spicy-cycles-learn.md
+++ b/.changeset/spicy-cycles-learn.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': minor
+---
+
+Add restyle as styling option

--- a/cli/README.md
+++ b/cli/README.md
@@ -12,13 +12,18 @@
 
 ## Sponsors
 
+NativeWind
+Restyle
+StyleSheets
+Tamagui
+
 Support this project by <a href="https://github.com/sponsors/danstepanov" target="_blank">becoming a sponsor</a>. Your logo will show up here with a link to your website.
 
 <a href="https://galaxies.dev/" target="_blank" style="margin-top: 10px;margin-right: 10px; margin-bottom: 10px;" ><img src="https://expostack.dev/galaxies-logo.svg"  style="border-radius: 50%;"></a> <a href="https://expo.dev/" target="_blank" style="margin: 10px;"><img src="https://expostack.dev/expo-logo.svg"  style="border-radius: 50%;"></a>
 
 ## Description
 
-This CLI tool is designed to help you get started with React Native and Expo as quickly as possible. The CLI options allow you to configure your project with Typescript, file-based routing with Expo Router, configuration-based navigation via React-Navigation, styling with StyleSheets, Tamagui, or NativeWind, and authentication via Supabase or Firebase.
+This CLI tool is designed to help you get started with React Native and Expo as quickly as possible. The CLI options allow you to configure your project with Typescript, file-based routing with Expo Router, configuration-based navigation via React-Navigation, styling with NativeWind, Restyle, StyleSheets, or Tamagui and authentication via Supabase or Firebase.
 
 You can also use flags such as `--noInstall`, `--noGit`, and `--default` in order to customize your project. The CLI will attempt to automatically determine your package manager of choice but you can also pass in your preferred package manager via `--npm`, `--yarn`, `--pnpm`, or `--bun`. Roadmap coming soon...
 
@@ -51,6 +56,7 @@ Each project is generated based on the results of the CLI, on a per-file basis. 
 | Expo System UI     | System UI Library   | v2      | System UI support                              |
 | Expo Web Browser   | Web Browser Library | v12     | Open links in the browser                      |
 | NativeWind         | UI Framework        | v2      | Tailwind CSS for React Native                  |
+| Restyle            | UI Framework        | v2      | Theme-based styling library for React Native   |
 | Tamagui            | UI Framework        | v1      | Universal UI with a smart optimizing compiler  |
 | Safe Area Context  | Safe Area Library   | v4      | Safe area support                              |
 | React Native Web   | Web Support         | v0.19   | React Native for Web                           |

--- a/cli/README.md
+++ b/cli/README.md
@@ -12,11 +12,6 @@
 
 ## Sponsors
 
-NativeWind
-Restyle
-StyleSheets
-Tamagui
-
 Support this project by <a href="https://github.com/sponsors/danstepanov" target="_blank">becoming a sponsor</a>. Your logo will show up here with a link to your website.
 
 <a href="https://galaxies.dev/" target="_blank" style="margin-top: 10px;margin-right: 10px; margin-bottom: 10px;" ><img src="https://expostack.dev/galaxies-logo.svg"  style="border-radius: 50%;"></a> <a href="https://expo.dev/" target="_blank" style="margin: 10px;"><img src="https://expostack.dev/expo-logo.svg"  style="border-radius: 50%;"></a>

--- a/cli/__tests__/cli-integration.test.ts
+++ b/cli/__tests__/cli-integration.test.ts
@@ -89,6 +89,24 @@ for (const packageManager of packageManagers) {
     expect(output).not.toContain('Installing dependencies');
   });
 
+  // --react-navigation stack restyle
+  test(`generates a project with react-navigation stack and restyle with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --react-navigation --stack --restyle --${packageManager}`);
+    expect(output).toContain(packageManager);
+  });
+
+  test(`generates a project with react-navigation stack and restyle and noGit with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --react-navigation --stack --restyle --noGit --${packageManager}`);
+    expect(output).toContain(packageManager);
+  });
+
+  test(`generates a project with react-navigation stack and restyle and noGit and noInstall with ${packageManager}`, async () => {
+    const output = await cli(
+      `myTestProject --react-navigation --stack --restyle --noGit --noInstall --${packageManager}`
+    );
+    expect(output).toContain(packageManager);
+  });
+
   // --react-navigation tabs
   test(`generates a project with react-navigation tabs with ${packageManager}`, async () => {
     const output = await cli(`myTestProject --react-navigation --tabs --${packageManager}`);
@@ -147,6 +165,24 @@ for (const packageManager of packageManagers) {
     expect(output).toContain(packageManager);
     expect(output).not.toContain('Initializing git');
     expect(output).not.toContain('Installing dependencies');
+  });
+
+  // --react-navigation tabs restyle
+  test(`generates a project with react-navigation tabs and restyle with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --react-navigation --tabs --restyle --${packageManager}`);
+    expect(output).toContain(packageManager);
+  });
+
+  test(`generates a project with react-navigation tabs and restyle and noGit with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --react-navigation --tabs --restyle --noGit --${packageManager}`);
+    expect(output).toContain(packageManager);
+  });
+
+  test(`generates a project with react-navigation tabs and restyle and noGit and noInstall with ${packageManager}`, async () => {
+    const output = await cli(
+      `myTestProject --react-navigation --tabs --restyle --noGit --noInstall --${packageManager}`
+    );
+    expect(output).toContain(packageManager);
   });
 
   // --react-navigation drawer
@@ -209,6 +245,24 @@ for (const packageManager of packageManagers) {
     expect(output).not.toContain('Installing dependencies');
   });
 
+  // --react-navigation drawer restyle
+  test(`generates a project with react-navigation drawer and restyle with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --react-navigation --drawer --restyle --${packageManager}`);
+    expect(output).toContain(packageManager);
+  });
+
+  test(`generates a project with react-navigation drawer and restyle and noGit with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --react-navigation --drawer --restyle --noGit --${packageManager}`);
+    expect(output).toContain(packageManager);
+  });
+
+  test(`generates a project with react-navigation drawer and restyle and noGit and noInstall with ${packageManager}`, async () => {
+    const output = await cli(
+      `myTestProject --react-navigation --drawer --restyle --noGit --noInstall --${packageManager}`
+    );
+    expect(output).toContain(packageManager);
+  });
+
   // --expo-router stack
   test(`generates a project with expo-router stack with ${packageManager}`, async () => {
     const output = await cli(`myTestProject --expo-router --stack --${packageManager}`);
@@ -266,6 +320,22 @@ for (const packageManager of packageManagers) {
     expect(output).toContain(packageManager);
     expect(output).not.toContain('Initializing git');
     expect(output).not.toContain('Installing dependencies');
+  });
+
+  // --expo-router stack restyle
+  test(`generates a project with expo-router stack and restyle with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --expo-router --stack --restyle --${packageManager}`);
+    expect(output).toContain(packageManager);
+  });
+
+  test(`generates a project with expo-router stack and restyle and noGit with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --expo-router --stack --restyle --noGit --${packageManager}`);
+    expect(output).toContain(packageManager);
+  });
+
+  test(`generates a project with expo-router stack and restyle and noGit and noInstall with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --expo-router --stack --restyle --noGit --noInstall --${packageManager}`);
+    expect(output).toContain(packageManager);
   });
 
   // --expo-router tabs
@@ -327,6 +397,22 @@ for (const packageManager of packageManagers) {
     expect(output).not.toContain('Installing dependencies');
   });
 
+  // --expo-router tabs restyle
+  test(`generates a project with expo-router tabs and restyle with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --expo-router --tabs --restyle --${packageManager}`);
+    expect(output).toContain(packageManager);
+  });
+
+  test(`generates a project with expo-router tabs and restyle and noGit with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --expo-router --tabs --restyle --noGit --${packageManager}`);
+    expect(output).toContain(packageManager);
+  });
+
+  test(`generates a project with expo-router tabs and restyle and noGit and noInstall with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --expo-router --tabs --restyle --noGit --noInstall --${packageManager}`);
+    expect(output).toContain(packageManager);
+  });
+
   // --expo-router drawer
   test(`generates a project with expo-router drawer with ${packageManager}`, async () => {
     const output = await cli(`myTestProject --expo-router --drawer --${packageManager}`);
@@ -386,5 +472,21 @@ for (const packageManager of packageManagers) {
     expect(output).toContain(packageManager);
     expect(output).not.toContain('Initializing git');
     expect(output).not.toContain('Installing dependencies');
+  });
+
+  // --expo-router drawer restyle
+  test(`generates a project with expo-router drawer and restyle with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --expo-router --drawer --restyle --${packageManager}`);
+    expect(output).toContain(packageManager);
+  });
+
+  test(`generates a project with expo-router drawer and restyle and noGit with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --expo-router --drawer --restyle --noGit --${packageManager}`);
+    expect(output).toContain(packageManager);
+  });
+
+  test(`generates a project with expo-router drawer and restyle and noGit and noInstall with ${packageManager}`, async () => {
+    const output = await cli(`myTestProject --expo-router --drawer --restyle --noGit --noInstall --${packageManager}`);
+    expect(output).toContain(packageManager);
   });
 }

--- a/cli/src/commands/create-expo-stack.ts
+++ b/cli/src/commands/create-expo-stack.ts
@@ -197,6 +197,17 @@ const command: GluegunCommand = {
             name: 'stylesheet',
             type: 'styling'
           });
+        } else if (options.restyle) {
+          try {
+            cliResults = clearStylingPackages(cliResults);
+            // Add stylesheet package
+            cliResults.packages.push({
+              name: 'restyle',
+              type: 'styling'
+            });
+          } catch (error) {
+            console.log({ error });
+          }
         }
         // if there is no style package, add stylesheet
         else if (cliResults.packages.find((p) => p.type === 'styling') === undefined) {

--- a/cli/src/templates/base/App.tsx.ejs
+++ b/cli/src/templates/base/App.tsx.ejs
@@ -47,7 +47,6 @@ import { StatusBar } from 'expo-status-bar';
     	);
 	}
 <% } else if (props.stylingPackage?.name === "restyle") {%>
-
     export default function App() {
       return (
         <ThemeProvider theme={theme}>

--- a/cli/src/templates/base/App.tsx.ejs
+++ b/cli/src/templates/base/App.tsx.ejs
@@ -6,6 +6,9 @@ import React from 'react';
   	import { View } from 'react-native';
 	import { TamaguiProvider, Text, styled } from 'tamagui';
 	import config from './tamagui.config'
+<% } else if (props.stylingPackage?.name === "restyle") {%>
+  import { ThemeProvider } from '@shopify/restyle';
+  import {theme, Text} from './theme';
 <% } else {%>
   	import { StyleSheet, Text, View } from 'react-native';
 <% } %>
@@ -43,6 +46,16 @@ import { StatusBar } from 'expo-status-bar';
 			</TamaguiProvider >
     	);
 	}
+<% } else if (props.stylingPackage?.name === "restyle") {%>
+
+    export default function App() {
+      return (
+        <ThemeProvider theme={theme}>
+          <Text>Open up App.tsx to start working on your app!</Text>
+          <StatusBar style="auto" />
+        </ThemeProvider>
+      );
+    }
 <% } else {%>
   	export default function App() {
 		return (

--- a/cli/src/templates/base/package.json.ejs
+++ b/cli/src/templates/base/package.json.ejs
@@ -16,6 +16,10 @@
     <% if (props.stylingPackage?.name === "nativewind") { %>
       "nativewind": "^2.0.11",
     <% } %>
+    
+    <% if (props.stylingPackage?.name === "restyle") { %>
+      "@shopify/restyle": "^2.4.2",
+    <% } %>
 
     <% if (props.stylingPackage?.name === "tamagui") { %>
       "tamagui": "1.74.8",
@@ -35,6 +39,7 @@
 
     <% if (props.navigationPackage?.name === "react-navigation") { %>
       "@react-navigation/stack": "^6.3.17",
+      "@expo/vector-icons": "^13.0.0",
     <% } %>
 
     <% if ((props.navigationPackage?.name === "react-navigation") && (props.stylingPackage?.name === "tamagui")) { %>

--- a/cli/src/templates/packages/expo-router/drawer/app/(drawer)/index.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/drawer/app/(drawer)/index.tsx.ejs
@@ -2,7 +2,9 @@
   import { Text, View } from "react-native";
 <% } else if (props.stylingPackage?.name === "tamagui") { %>
   import { YStack, H2, Separator, Theme } from "tamagui";
-<% } else { %>
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+  import { Box, Text } from 'theme';
+<% } else if (props.stylingPackage?.name === "stylesheet") { %>
   import { StyleSheet, Text, View } from "react-native";
 <% } %>
 
@@ -24,6 +26,13 @@ const Page = () => {
       </YStack>
     </Theme>
   );    
+  <% } else if (props.stylingPackage?.name === "restyle") { %>
+    return (
+      <Box flex={1} alignItems="center" justifyContent="center">
+        <Text variant="title">Home</Text>
+        <Box height={1} marginVertical="l_32" width="80%" />
+      </Box>
+    );
   <% } else { %>
       return (
     <View style={styles.container}>

--- a/cli/src/templates/packages/expo-router/drawer/app/(drawer)/news.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/drawer/app/(drawer)/news.tsx.ejs
@@ -2,7 +2,9 @@
   import { Text, View } from "react-native";
 <% } else if (props.stylingPackage?.name === "tamagui") { %>
   import { YStack, H2, Separator, Theme } from "tamagui";
-<% } else { %>
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+  import { Box, Text } from 'theme';
+<% } else if (props.stylingPackage?.name === "stylesheet") { %>
   import { StyleSheet, Text, View } from "react-native";
 <% } %>
 
@@ -24,6 +26,13 @@ const Page = () => {
       </YStack>
     </Theme>
   );    
+  <% } else if (props.stylingPackage?.name === "restyle") { %>
+    return (
+      <Box flex={1} alignItems="center" justifyContent="center">
+        <Text variant="title">News</Text>
+        <Box height={1} marginVertical="l_32" width="80%" />
+      </Box>
+    );
   <% } else { %>
       return (
     <View style={styles.container}>

--- a/cli/src/templates/packages/expo-router/drawer/app/[...unmatched].tsx.ejs
+++ b/cli/src/templates/packages/expo-router/drawer/app/[...unmatched].tsx.ejs
@@ -6,9 +6,15 @@ import { Link, Stack } from 'expo-router';
 <% } else if (props.stylingPackage?.name === "tamagui") { %>
   import { YStack } from "tamagui";
 	import { Container, Main, Subtitle, Title } from "../tamagui.config";
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+  import { Box, Text, makeStyles } from 'theme';
 <% } %>
 
 export default function NotFoundScreen() {
+<% if (props.stylingPackage?.name === "restyle") { %>
+  const styles = useStyles();
+<% } %>
+
   return (
       <% if (props.stylingPackage?.name === "nativewind") {%>
         <>
@@ -32,6 +38,18 @@ export default function NotFoundScreen() {
             </YStack>
           </Main>
         </Container>
+      <% } else if (props.stylingPackage?.name === "restyle") {%>
+        <>
+          <Stack.Screen options={{ title: 'Oops!' }} />
+          <Box flex={1} justifyContent="center" alignItems="center" padding="ml_24">
+            <Text variant="title">This screen doesn't exist.</Text>
+            <Link href="/" style={styles.link}>
+              <Text variant="body" color="blue">
+                Go to home screen!
+              </Text>
+            </Link>
+          </Box>
+        </>
       <% } else { %>
         <>
           <Stack.Screen options={{ title: "Oops!" }} />
@@ -74,4 +92,11 @@ export default function NotFoundScreen() {
       color: '#2e78b7',
     },
   });
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+  const useStyles = makeStyles((theme) => ({
+    link: {
+      marginTop: theme.spacing.m_16,
+      paddingVertical: theme.spacing.m_16,
+    },
+  }));
 <% } %>

--- a/cli/src/templates/packages/expo-router/drawer/app/_layout.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/drawer/app/_layout.tsx.ejs
@@ -10,7 +10,11 @@ import { Slot } from 'expo-router';
 	import config from '../tamagui.config'
 
 	SplashScreen.preventAutoHideAsync();
-<% }  %>
+<% }  else if (props.stylingPackage?.name === "restyle") { %>
+  import { ThemeProvider } from '@shopify/restyle';
+  
+  import { theme } from '../theme';
+<% } %>
 
 export const unstable_settings = {
 	// Ensure that reloading on `/modal` keeps a back button present.
@@ -36,12 +40,16 @@ export default function RootLayout() {
   	return (
     	<% if (props.stylingPackage?.name === "tamagui") { %>
     		<TamaguiProvider config={config}>
+    	<% } else if (props.stylingPackage?.name === "restyle") { %>
+    		<ThemeProvider theme={theme}>
     	<% } %>
 		  <GestureHandlerRootView style={{ flex: 1 }}>
       <Slot />
     </GestureHandlerRootView>
 		<% if (props.stylingPackage?.name === "tamagui") { %>
 			</TamaguiProvider>
-		<% } %>
+    <% } else if (props.stylingPackage?.name === "restyle") { %>
+    	</ThemeProvider>
+    <% } %>
   	);
 }

--- a/cli/src/templates/packages/expo-router/stack/app/[...unmatched].tsx.ejs
+++ b/cli/src/templates/packages/expo-router/stack/app/[...unmatched].tsx.ejs
@@ -6,9 +6,15 @@ import { Link, Stack } from 'expo-router';
 <% } else if (props.stylingPackage?.name === "tamagui") { %>
   import { YStack } from "tamagui";
 	import { Container, Main, Subtitle, Title } from "../tamagui.config";
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+  import { Box, Text, makeStyles } from 'theme';
 <% } %>
 
 export default function NotFoundScreen() {
+<% if (props.stylingPackage?.name === "restyle") { %>
+  const styles = useStyles();
+<% } %>
+
   return (
       <% if (props.stylingPackage?.name === "nativewind") {%>
         <>
@@ -32,6 +38,18 @@ export default function NotFoundScreen() {
             </YStack>
           </Main>
         </Container>
+      <% } else if (props.stylingPackage?.name === "restyle") {%>
+        <>
+          <Stack.Screen options={{ title: 'Oops!' }} />
+          <Box flex={1} justifyContent="center" alignItems="center" padding="ml_24">
+            <Text variant="title">This screen doesn't exist.</Text>
+            <Link href="/" style={styles.link}>
+              <Text variant="body" color="blue">
+                Go to home screen!
+              </Text>
+            </Link>
+          </Box>
+        </>
       <% } else { %>
         <>
           <Stack.Screen options={{ title: "Oops!" }} />
@@ -74,4 +92,11 @@ export default function NotFoundScreen() {
       color: '#2e78b7',
     },
   });
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+  const useStyles = makeStyles((theme) => ({
+    link: {
+      marginTop: theme.spacing.m_16,
+      paddingVertical: theme.spacing.m_16,
+    },
+  }));
 <% } %>

--- a/cli/src/templates/packages/expo-router/stack/app/_layout.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/stack/app/_layout.tsx.ejs
@@ -5,9 +5,11 @@
   import { TamaguiProvider } from 'tamagui';
 
   import config from '../tamagui.config';
-<% } else { %>
-	import { Stack } from "expo-router";
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+  import { ThemeProvider } from '@shopify/restyle';
+  import { theme } from 'theme';
 <% } %>
+	import { Stack } from "expo-router";
 
 export default function Layout() {
 
@@ -29,10 +31,14 @@ export default function Layout() {
 	return (
 		<% if (props.stylingPackage?.name === "tamagui") { %>
 			<TamaguiProvider config={config}>
+		<% } else if (props.stylingPackage?.name === "restyle") { %>
+			<ThemeProvider theme={theme}>
 		<% } %>
-		<Stack />
+		    <Stack />
 		<% if (props.stylingPackage?.name === "tamagui") { %>
 			</TamaguiProvider>
+		<% } else if (props.stylingPackage?.name === "restyle") { %>
+			</ThemeProvider >
 		<% } %>
 	);
 }

--- a/cli/src/templates/packages/expo-router/stack/app/details.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/stack/app/details.tsx.ejs
@@ -5,6 +5,9 @@
   import { Stack, useRouter } from "expo-router";
 	import { Button, Text, YStack } from "tamagui";
 	import { Container, Main, Subtitle, Title } from "../tamagui.config";
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+  import { Box, Text } from 'theme';
+  import { TouchableOpacity } from 'react-native';
 <% } else { %>
 	import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 <% } %>
@@ -28,6 +31,17 @@ export default function Details() {
 		const BackButton = () => (
 			<Button unstyled flexDirection="row" backgroundColor="transparent" paddingLeft={0} pressStyle={{ opacity: 0.5 }} onPress={router.back} icon={<Feather name="chevron-left" size={16} color="#007AFF" />}><Text color="#007AFF">Back</Text></Button>
 		)
+	<% } else if (props.stylingPackage?.name === "restyle") { %>
+    const BackButton = () => (
+      <TouchableOpacity onPress={router.back}>
+        <Box flexDirection="row">
+          <Feather name="chevron-left" size={16} color="#007AFF" />
+          <Text color="blue" marginLeft="xs_4">
+            Back
+          </Text>
+        </Box>
+      </TouchableOpacity>
+    );
 	<% } else { %>
 		const BackButton = () => (
 			<TouchableOpacity onPress={router.back}>
@@ -58,6 +72,18 @@ export default function Details() {
 					</YStack>
 				</Main>
 			</Container>
+		<% } else if (props.stylingPackage?.name === "restyle") { %>
+      <>
+        <Stack.Screen options={{ title: 'Details', headerLeft: () => <BackButton /> }} />
+        <Box flex={1} padding="ml_24">
+          <Box flex={1} maxWidth={960}>
+            <Text variant="extra_large">Details</Text>
+            <Text variant="large" color="darkGray">
+              Showing details for user {name}.
+            </Text>
+          </Box>
+        </Box>
+      </>
 		<% } else { %>
 			<View style={styles.container}>
         <Stack.Screen options={{ title: "Details", headerLeft: () => <BackButton /> }} />

--- a/cli/src/templates/packages/expo-router/stack/app/index.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/stack/app/index.tsx.ejs
@@ -3,6 +3,9 @@
 <% } else if (props.stylingPackage?.name === "tamagui") { %>
 	import { YStack } from "tamagui";
 	import { Container, Main, Title, Subtitle, Button, ButtonText } from '../tamagui.config';
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+  import { TouchableOpacity } from 'react-native';
+  import { Box, Text, makeStyles } from 'theme';
 <% } else { %>
 	import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 <% } %>
@@ -11,6 +14,10 @@ import { Stack } from "expo-router";
 import { Link } from "expo-router";
 
 export default function Page() {
+  <% if (props.stylingPackage?.name === "restyle") { %>
+    const styles = useStyles();
+  <% } %>
+
 	return (
 		<% if (props.stylingPackage?.name === "nativewind") { %>
 			<View className={styles.container}>
@@ -27,7 +34,7 @@ export default function Page() {
 				</Link>
 				</View>
 			</View>
-			<% } else if (props.stylingPackage?.name === "tamagui") { %>
+		<% } else if (props.stylingPackage?.name === "tamagui") { %>
 			<Container>
 				<Main>
           <Stack.Screen options={{ title: "Overview" }} />
@@ -40,7 +47,30 @@ export default function Page() {
           </Link>
 				</Main>
 			</Container>
-			<% } else { %>
+		<% } else if (props.stylingPackage?.name === "restyle") { %>
+      <>
+        <Stack.Screen options={{ title: "Overview" }} />
+        <Box flex={1} padding="ml_24">
+          <Box flex={1} maxWidth={960} justifyContent="space-between">
+            <Box>
+              <Text variant="extra_large">Hello World</Text>
+              <Text variant="large" color="darkGray">
+                This is the first page of your app.
+              </Text>
+            </Box>
+            <Link href={{ pathname: '/details', params: { name: 'Dan' } }} asChild>
+              <TouchableOpacity
+                style={styles.button}
+              >
+                <Text variant="body" textAlign="center" color="white" fontWeight="600">
+                  Show Details
+                </Text>
+              </TouchableOpacity>
+            </Link>
+          </Box>
+        </Box>
+      </>
+  	<% } else { %>
 			<View style={styles.container}>
 				<View style={styles.main}>
           <Stack.Screen options={{ title: "Overview" }} />
@@ -68,6 +98,25 @@ export default function Page() {
 		title: "text-[64px] font-bold",
 		subtitle: "text-4xl text-gray-700",
 	};
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+  const useStyles = makeStyles((theme) => ({
+    button: {
+      alignItems: 'center',
+      backgroundColor: theme.colors.purple,
+      borderRadius: theme.borderRadii.xl_24,
+      elevation: 5,
+      flexDirection: 'row',
+      justifyContent: 'center',
+      padding: theme.spacing.m_16,
+      shadowColor: theme.colors.black,
+      shadowOffset: {
+        height: 2,
+        width: 0,
+      },
+      shadowOpacity: 0.25,
+      shadowRadius: 3.84,
+    },
+  }));
 <% } else if (props.stylingPackage?.name === "stylesheet") { %>
 	const styles = StyleSheet.create({
 		button: {

--- a/cli/src/templates/packages/expo-router/tabs/app/(tabs)/index.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/tabs/app/(tabs)/index.tsx.ejs
@@ -2,6 +2,8 @@
     import { Text, View } from "react-native";
 <% } else if (props.stylingPackage?.name === "tamagui") { %>
     import { YStack, H2, Separator, Theme } from "tamagui";
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+    import { Box, Text } from 'theme';
 <% } else { %>
     import { StyleSheet, Text, View } from "react-native";
 <% } %>
@@ -27,6 +29,14 @@ export default function TabOneScreen() {
 				</YStack>
 			</Theme>
 		);    
+    <% } else if (props.stylingPackage?.name === "restyle") { %>
+      return (
+        <Box flex={1} alignItems="center" justifyContent="center">
+          <Text variant="title">Tab One</Text>
+          <Box height={1} marginVertical="l_32" width="80%" />
+          <EditScreenInfo path="app/(tabs)/index.tsx" />
+        </Box>
+      );  
     <% } else { %>
         return (
 			<View style={styles.container}>

--- a/cli/src/templates/packages/expo-router/tabs/app/(tabs)/two.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/tabs/app/(tabs)/two.tsx.ejs
@@ -2,6 +2,8 @@
     import { Text, View } from "react-native";
 <% } else if (props.stylingPackage?.name === "tamagui") { %>
     import { YStack, H2, Separator, Theme } from "tamagui";
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+    import { Box, Text } from 'theme';
 <% } else { %>
     import { StyleSheet, Text, View } from "react-native";
 <% } %>
@@ -27,6 +29,14 @@ export default function TabTwoScreen() {
 				</YStack>
 			</Theme>
 		);    
+    <% } else if (props.stylingPackage?.name === "restyle") { %>
+      return (
+        <Box flex={1} alignItems="center" justifyContent="center">
+          <Text variant="title">Tab Two</Text>
+          <Box height={1} marginVertical="l_32" width="80%" />
+          <EditScreenInfo path="app/(tabs)/two.tsx" />
+        </Box>
+      ); 
     <% } else { %>
         return (
 			<View style={styles.container}>

--- a/cli/src/templates/packages/expo-router/tabs/app/[...unmatched].tsx.ejs
+++ b/cli/src/templates/packages/expo-router/tabs/app/[...unmatched].tsx.ejs
@@ -6,9 +6,15 @@ import { Link, Stack } from 'expo-router';
 <% } else if (props.stylingPackage?.name === "tamagui") { %>
   import { YStack } from "tamagui";
 	import { Container, Main, Subtitle, Title } from "../tamagui.config";
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+  import { Box, Text, makeStyles } from 'theme';
 <% } %>
 
 export default function NotFoundScreen() {
+<% if (props.stylingPackage?.name === "restyle") { %>
+  const styles = useStyles();
+<% } %>
+
   return (
       <% if (props.stylingPackage?.name === "nativewind") {%>
         <>
@@ -32,6 +38,18 @@ export default function NotFoundScreen() {
             </YStack>
           </Main>
         </Container>
+      <% } else if (props.stylingPackage?.name === "restyle") {%>
+        <>
+          <Stack.Screen options={{ title: 'Oops!' }} />
+          <Box flex={1} justifyContent="center" alignItems="center" padding="ml_24">
+            <Text variant="title">This screen doesn't exist.</Text>
+            <Link href="/" style={styles.link}>
+              <Text variant="body" color="blue">
+                Go to home screen!
+              </Text>
+            </Link>
+          </Box>
+        </>
       <% } else { %>
         <>
           <Stack.Screen options={{ title: "Oops!" }} />
@@ -74,4 +92,11 @@ export default function NotFoundScreen() {
       color: '#2e78b7',
     },
   });
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+  const useStyles = makeStyles((theme) => ({
+    link: {
+      marginTop: theme.spacing.m_16,
+      paddingVertical: theme.spacing.m_16,
+    },
+  }));
 <% } %>

--- a/cli/src/templates/packages/expo-router/tabs/app/_layout.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/tabs/app/_layout.tsx.ejs
@@ -7,6 +7,10 @@
 	import config from '../tamagui.config'
 
 	SplashScreen.preventAutoHideAsync();
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+  import { ThemeProvider } from '@shopify/restyle';
+  import { Stack } from 'expo-router';
+  import { theme } from 'theme';
 <% } else { %>
 	import { Stack } from "expo-router";
 <% } %>
@@ -35,6 +39,8 @@ export default function RootLayout() {
   	return (
     	<% if (props.stylingPackage?.name === "tamagui") { %>
     		<TamaguiProvider config={config}>
+    	<% } else if (props.stylingPackage?.name === "restyle") { %>
+    		<ThemeProvider theme={theme}>
     	<% } %>
 		<Stack>
 			<Stack.Screen name="(tabs)" options={{ headerShown: false }} />
@@ -42,6 +48,8 @@ export default function RootLayout() {
 		</Stack>
 		<% if (props.stylingPackage?.name === "tamagui") { %>
 			</TamaguiProvider>
+		<% } else if (props.stylingPackage?.name === "restyle") { %>
+			</ThemeProvider>
 		<% } %>
   	);
 }

--- a/cli/src/templates/packages/expo-router/tabs/app/modal.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/tabs/app/modal.tsx.ejs
@@ -3,6 +3,9 @@
 <% } else if (props.stylingPackage?.name === "tamagui") { %>
     import { YStack, Paragraph, Separator, Theme } from "tamagui";
 	import { Platform } from 'react-native'
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+  import { Platform } from 'react-native';
+  import { Box, Text } from 'theme';
 <% } else { %>
     import { Platform, StyleSheet, Text, View } from "react-native";
 <% } %>
@@ -31,6 +34,15 @@ export default function ModalScreen() {
 				</YStack>
 			</Theme>
 		);
+    <% } else if (props.stylingPackage?.name === "restyle") { %>
+      return (
+        <Box flex={1} alignItems="center" justifyContent="center">
+          <StatusBar style={Platform.OS === 'ios' ? 'light' : 'auto'} />
+          <Text variant="title">Modal</Text>
+          <Box height={1} marginVertical="l_32" width="80%" />
+          <EditScreenInfo path="app/modal.tsx" />
+        </Box>
+      );
     <% } else { %>
         return (
 			<View style={styles.container}>

--- a/cli/src/templates/packages/expo-router/tabs/components/edit-screen-info.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/tabs/components/edit-screen-info.tsx.ejs
@@ -1,8 +1,9 @@
-import React from "react";
 <% if (props.stylingPackage?.name === "nativewind") { %>
     import { Text, View } from "react-native";
 <% } else if (props.stylingPackage?.name === "tamagui") { %>
     import { YStack, H4, Paragraph } from "tamagui"
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+    import { Box, Text } from 'theme';
 <% } else { %>
     import { StyleSheet, Text, View } from "react-native";
 <% } %>
@@ -39,6 +40,20 @@ export default function EditScreenInfo({ path }: { path: string }) {
                     </Paragraph>
                 </YStack>
             </YStack>
+        );
+    <% } else if (props.stylingPackage?.name === "restyle") { %>
+        return (
+          <Box alignItems="center" marginHorizontal="xl_64">
+            <Text variant="body" lineHeight={24} textAlign="center">
+              Open up the code for this screen:
+            </Text>
+            <Box borderRadius="s_3" paddingHorizontal="xs_4" marginVertical="s_8">
+              <Text>{path}</Text>
+            </Box>
+            <Text variant="body" lineHeight={24} textAlign="center">
+              Change any of the text, save the file, and your app will automatically update.
+            </Text>
+          </Box>
         );
     <% } else { %>
         return (

--- a/cli/src/templates/packages/react-navigation/App.tsx.ejs
+++ b/cli/src/templates/packages/react-navigation/App.tsx.ejs
@@ -8,7 +8,11 @@ import "react-native-gesture-handler";
 	import config from './tamagui.config'
 
 	SplashScreen.preventAutoHideAsync();
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+  import { ThemeProvider } from '@shopify/restyle';
+  import { theme } from 'theme';
 <% } %>
+
 import RootStack from "./src/navigation";
 
 export default function App() {
@@ -33,7 +37,13 @@ export default function App() {
 				<RootStack />
 			</TamaguiProvider>
 		);
-	<% } else { %>
+	<% } else if (props.stylingPackage?.name === "restyle") { %>
+		return (
+      <ThemeProvider theme={theme}>
+        <RootStack />
+      </ThemeProvider>
+    );
+	<% } else { %> 
 		return <RootStack />;
 	<% } %>
 }

--- a/cli/src/templates/packages/react-navigation/components/edit-screen-info.tsx.ejs
+++ b/cli/src/templates/packages/react-navigation/components/edit-screen-info.tsx.ejs
@@ -1,6 +1,8 @@
 import React from "react";
 <% if (props.stylingPackage?.name === "nativewind") { %>
   import { Text, View } from "react-native";
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+  import { Box, Text } from 'theme';
 <% } else { %>
   import { StyleSheet, Text, View } from "react-native";
 <% } %>
@@ -28,6 +30,26 @@ import React from "react";
           </Text>
         </View>
       </View>
+    );
+  }
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+  export default function EditScreenInfo({ path }: { path: string }) {
+    return (
+      <Box>
+        <Box alignItems="center" marginHorizontal="xl_64">
+          <Text variant="body" lineHeight={24} textAlign="center">
+            Open up the code for this screen:
+          </Text>
+
+          <Box borderRadius="s_3" paddingHorizontal="xs_4" marginVertical="s_8">
+            <Text>{path}</Text>
+          </Box>
+
+          <Text variant="body" lineHeight={24} textAlign="center">
+            Change any of the text, save the file, and your app will automatically update.
+          </Text>
+        </Box>
+      </Box>
     );
   }
 <% } else { %>
@@ -66,7 +88,7 @@ import React from "react";
     helpLink: "py-4",
     helpLinkText: "text-center"
   };
-<% } else { %>
+<% } else if (props.stylingPackage?.name !== "restyle") { %>
   const styles = StyleSheet.create({
     codeHighlightContainer: {
       borderRadius: 3,

--- a/cli/src/templates/packages/react-navigation/navigation/index.tsx.ejs
+++ b/cli/src/templates/packages/react-navigation/navigation/index.tsx.ejs
@@ -6,6 +6,8 @@
 		import { Text, View } from "react-native";
 	<% } else if (props.stylingPackage?.name === "tamagui") { %>
 		import { Button, Text } from "tamagui";
+	<% } else if (props.stylingPackage?.name === "restyle") { %>
+    import { Box, Text, useTheme } from 'theme';
 	<% } else { %>
 		import { Text, View, StyleSheet } from "react-native";
 	<% } %>
@@ -21,6 +23,9 @@
 	const Stack = createStackNavigator<RootStackParamList>();
 
 	export default function RootStack() {
+    <% if (props.stylingPackage?.name === "restyle") { %>
+    const { colors } = useTheme();
+    <% } %>
 		return (
 			<NavigationContainer>
 				<Stack.Navigator initialRouteName="Overview">
@@ -53,6 +58,17 @@
 									</Button>
 								),
 							})}
+						<% } else if (props.stylingPackage?.name === "restyle") { %>
+              options={({ navigation }) => ({
+                headerLeft: () => (
+                  <Box flexDirection="row" paddingLeft="m_16">
+                    <Feather name="chevron-left" size={16} color={colors.blue} />
+                    <Text marginLeft="xs_4" color="blue" onPress={navigation.goBack}>
+                      Back
+                    </Text>
+                  </Box>
+                ),
+              })}
 						<% } else { %>
 							options={({ navigation }) => ({
 								headerLeft: () => (
@@ -112,13 +128,13 @@
 					<Stack.Screen
 						name="Modal"
 						component={Modal}
-						options={{ presentation: "modal", headerLeft: null }}
+						options={{ presentation: "modal", headerLeft: () => null }}
 					/>
 				</Stack.Navigator>
 			</NavigationContainer>
 		);
 	}
-	<% } else if (props.navigationPackage?.options.type === 'drawer') { %>
+<% } else if (props.navigationPackage?.options.type === 'drawer') { %>
 		import { NavigationContainer } from "@react-navigation/native";
 		import { createStackNavigator } from '@react-navigation/stack';
 	
@@ -150,4 +166,4 @@
 				</NavigationContainer>
 			);
 		}
-	<% } %>
+<% } %>

--- a/cli/src/templates/packages/react-navigation/navigation/tab-navigator.tsx.ejs
+++ b/cli/src/templates/packages/react-navigation/navigation/tab-navigator.tsx.ejs
@@ -1,7 +1,9 @@
 import FontAwesome from "@expo/vector-icons/FontAwesome";
-import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { StackScreenProps } from '@react-navigation/stack';
 import { Pressable, StyleSheet } from "react-native";
 
+import { RootStackParamList } from '.';
 import One from "../screens/one";
 import Two from "../screens/two";
 
@@ -14,7 +16,9 @@ function TabBarIcon(props: {
   return <FontAwesome size={28} style={styles.tabBarIcon} {...props} />;
 }
 
-export default function TabLayout({ navigation }) {
+type Props = StackScreenProps<RootStackParamList, 'TabNavigator'>;
+
+export default function TabLayout({ navigation }: Props) {
   return (
     <Tab.Navigator
       screenOptions={{

--- a/cli/src/templates/packages/react-navigation/screens/details.tsx.ejs
+++ b/cli/src/templates/packages/react-navigation/screens/details.tsx.ejs
@@ -4,6 +4,8 @@ import { RouteProp, useRoute } from "@react-navigation/native";
 <% } else if (props.stylingPackage?.name === "tamagui") { %>
 	import { YStack } from "tamagui";
 	import { Container, Main, Subtitle, Title } from "../../tamagui.config";
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+	import { Box, Text } from 'theme';
 <% } else { %>
 	import { View, StyleSheet, Text } from "react-native";
 <% } %>
@@ -33,6 +35,17 @@ export default function Details() {
 				</Main>
 			</Container>
 		);
+	<% } else if (props.stylingPackage?.name === "restyle") { %>
+    return (
+      <Box flex={1} padding="ml_24">
+        <Box flex={1} maxWidth={960}>
+          <Text variant="extra_large">Details</Text>
+          <Text variant="large" color="darkGray">
+            Showing details for user {router.params.name}.
+          </Text>
+        </Box>
+      </Box>
+    );
 	<% } else { %>
 		return (
 			<View style={styles.container}>

--- a/cli/src/templates/packages/react-navigation/screens/modal.tsx.ejs
+++ b/cli/src/templates/packages/react-navigation/screens/modal.tsx.ejs
@@ -3,6 +3,9 @@
 <% } else if (props.stylingPackage?.name === "tamagui") { %>
   	import { YStack, Paragraph, Separator, Theme } from "tamagui";
 	import { Platform } from 'react-native'
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+    import { Platform } from 'react-native';
+    import { Box, Text, makeStyles } from 'theme';
 <% } else { %>
   	import { Platform, StyleSheet, Text, View } from "react-native";
 <% } %>
@@ -20,7 +23,7 @@ export default function Modal() {
 				<EditScreenInfo path="src/screens/modal.tsx" />
 			</View>
 		)
-			<% } else if (props.stylingPackage?.name === "tamagui") { %>
+	<% } else if (props.stylingPackage?.name === "tamagui") { %>
 		return (
 					<Theme name="light">
 						<YStack flex={1} alignItems="center" justifyContent="center">
@@ -31,6 +34,17 @@ export default function Modal() {
 						</YStack>
 					</Theme>
 				);
+	<% } else if (props.stylingPackage?.name === "restyle") { %>
+    const styles = useStyles();
+
+    return (
+      <Box flex={1} alignItems="center" justifyContent="center">
+        <StatusBar style={Platform.OS === 'ios' ? 'light' : 'auto'} />
+        <Text variant="title">Modal</Text>
+        <Box style={styles.separator} />
+        <EditScreenInfo path="src/screens/modal.tsx" />
+      </Box>
+    );
 	<% } else { %>
 		return (
 			<View style={styles.container}>
@@ -49,6 +63,16 @@ export default function Modal() {
 		separator: "h-[1px] my-7 w-4/5 bg-gray-200",
 		title: "text-xl font-bold"
 	};
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+  const useStyles = makeStyles((theme) => ({
+    separator: {
+      backgroundColor: theme.colors.gray,
+      height: 1,
+      marginVertical: theme.spacing.l_32,
+      opacity: 0.25,
+      width: '80%',
+    },
+  }));
 <% } else if (props.stylingPackage?.name === "stylesheet") { %>
   	const styles = StyleSheet.create({
 		container: {

--- a/cli/src/templates/packages/react-navigation/screens/one.tsx.ejs
+++ b/cli/src/templates/packages/react-navigation/screens/one.tsx.ejs
@@ -2,6 +2,8 @@
   	import { Text, View } from "react-native";
 <% } else if (props.stylingPackage?.name === "tamagui") { %>
   	import { YStack, H2, Separator, Theme } from "tamagui";
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+    import { Box, Text, makeStyles } from 'theme';
 <% } else { %>
   	import { StyleSheet, Text, View } from "react-native";
 <% } %>
@@ -27,6 +29,16 @@ export default function TabOneScreen() {
 				</YStack>
 			</Theme>
 		);    
+	<% } else if (props.stylingPackage?.name === "restyle") { %>
+    const styles = useStyles();
+
+    return (
+      <Box flex={1} alignItems="center" justifyContent="center">
+        <Text variant="title">Tab One</Text>
+        <Box style={styles.separator} />
+        <EditScreenInfo path="src/screens/one.tsx" />
+      </Box>
+    );   
 	<% } else { %>
 		return (
 			<View style={styles.container}>
@@ -44,6 +56,16 @@ export default function TabOneScreen() {
 		separator: "h-[1px] my-7 w-4/5 bg-gray-200",
 		title: "text-xl font-bold"
 	};
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+    const useStyles = makeStyles((theme) => ({
+      separator: {
+        backgroundColor: theme.colors.gray,
+        height: 1,
+        marginVertical: theme.spacing.l_32,
+        opacity: 0.25,
+        width: '80%',
+      },
+    }));
 <% } else if (props.stylingPackage?.name === "stylesheet") { %>
   	const styles = StyleSheet.create({
 		container: {

--- a/cli/src/templates/packages/react-navigation/screens/overview.tsx.ejs
+++ b/cli/src/templates/packages/react-navigation/screens/overview.tsx.ejs
@@ -5,6 +5,9 @@ import { StackNavigationProp } from "@react-navigation/stack";
 <% } else if (props.stylingPackage?.name === "tamagui") { %>
 	import { YStack } from "tamagui";
 	import { Container, Main, Title, Subtitle, Button, ButtonText } from '../../tamagui.config';
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+  import { TouchableOpacity } from 'react-native';
+  import { Box, Text, makeStyles } from 'theme';
 <% } else { %>
 	import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 <% } %>
@@ -13,6 +16,7 @@ import { RootStackParamList } from "../navigation";
 type OverviewScreenNavigationProps = StackNavigationProp<RootStackParamList, "Overview">;
 
 export default function Overview() {
+  const styles = useStyles();
 	const navigation = useNavigation<OverviewScreenNavigationProps>();
   	<% if (props.stylingPackage?.name === "nativewind") { %>
 		return (
@@ -42,6 +46,26 @@ export default function Overview() {
 				</Main>
 			</Container>
 		);
+	<% } else if (props.stylingPackage?.name === "restyle") { %>
+    return (
+      <Box flex={1} padding="ml_24">
+        <Box flex={1} maxWidth={960} justifyContent="space-between">
+          <Box>
+            <Text variant="extra_large">Hello World</Text>
+            <Text variant="large" color="darkGray">
+              This is the first page of your app.
+            </Text>
+          </Box>
+          <TouchableOpacity
+            style={styles.button}
+            onPress={() => navigation.navigate('Details', { name: 'Dan' })}>
+            <Text variant="body" textAlign="center" color="white" fontWeight="600">
+              Show Details
+            </Text>
+          </TouchableOpacity>
+        </Box>
+      </Box>
+    );
 	<% } else { %>
 		return (
 			<View style={styles.container}>
@@ -68,6 +92,25 @@ export default function Overview() {
 		title: "text-[64px] font-bold",
 		subtitle: "text-4xl text-gray-700",
 	};
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+  const useStyles = makeStyles((theme) => ({
+    button: {
+      alignItems: 'center',
+      backgroundColor: theme.colors.purple,
+      borderRadius: theme.borderRadii.xl_24,
+      elevation: 5,
+      flexDirection: 'row',
+      justifyContent: 'center',
+      padding: theme.spacing.m_16,
+      shadowColor: theme.colors.black,
+      shadowOffset: {
+        height: 2,
+        width: 0,
+      },
+      shadowOpacity: 0.25,
+      shadowRadius: 3.84,
+    },
+  }));
 <% } else if (props.stylingPackage?.name === "stylesheet") { %>
 	const styles = StyleSheet.create({
 		button: {

--- a/cli/src/templates/packages/react-navigation/screens/two.tsx.ejs
+++ b/cli/src/templates/packages/react-navigation/screens/two.tsx.ejs
@@ -2,6 +2,8 @@
   	import { Text, View } from "react-native";
 <% } else if (props.stylingPackage?.name === "tamagui") { %>
   	import { YStack, H2, Separator, Theme } from "tamagui";
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+    import { Box, Text, makeStyles } from 'theme';
 <% } else { %>
   	import { StyleSheet, Text, View } from "react-native";
 <% } %>
@@ -26,7 +28,17 @@ export default function TabTwoScreen() {
 					<EditScreenInfo path="src/screens/two.tsx" />
 				</YStack>
 			</Theme>
-		);
+		);    
+	<% } else if (props.stylingPackage?.name === "restyle") { %>
+    const styles = useStyles();
+
+    return (
+      <Box flex={1} alignItems="center" justifyContent="center">
+        <Text variant="title">Tab Two</Text>
+        <Box style={styles.separator} />
+        <EditScreenInfo path="src/screens/two.tsx" />
+      </Box>
+    );   
 	<% } else { %>
 		return (
 			<View style={styles.container}>
@@ -44,6 +56,16 @@ export default function TabTwoScreen() {
 		separator: "h-[1px] my-7 w-4/5 bg-gray-200",
 		title: "text-xl font-bold"
 	};
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+    const useStyles = makeStyles((theme) => ({
+      separator: {
+        backgroundColor: theme.colors.gray,
+        height: 1,
+        marginVertical: theme.spacing.l_32,
+        opacity: 0.25,
+        width: '80%',
+      },
+    }));
 <% } else if (props.stylingPackage?.name === "stylesheet") { %>
   	const styles = StyleSheet.create({
 		container: {

--- a/cli/src/templates/packages/restyle/theme/Box.tsx.ejs
+++ b/cli/src/templates/packages/restyle/theme/Box.tsx.ejs
@@ -1,0 +1,6 @@
+import { createBox } from '@shopify/restyle';
+import { Theme } from './theme';
+
+const Box = createBox<Theme>();
+
+export default Box;

--- a/cli/src/templates/packages/restyle/theme/Text.tsx.ejs
+++ b/cli/src/templates/packages/restyle/theme/Text.tsx.ejs
@@ -1,0 +1,6 @@
+import { createText } from '@shopify/restyle';
+import { Theme } from './theme';
+
+const Text = createText<Theme>();
+
+export default Text;

--- a/cli/src/templates/packages/restyle/theme/index.ts.ejs
+++ b/cli/src/templates/packages/restyle/theme/index.ts.ejs
@@ -1,0 +1,6 @@
+import Box from './Box';
+import Text from './Text';
+import theme, { useTheme, Theme, makeStyles } from './theme';
+
+export { theme, Box, Text, useTheme, Theme, makeStyles };
+

--- a/cli/src/templates/packages/restyle/theme/theme.ts.ejs
+++ b/cli/src/templates/packages/restyle/theme/theme.ts.ejs
@@ -1,0 +1,67 @@
+import { createTheme, useTheme as useRestyleTheme } from '@shopify/restyle';
+import { ImageStyle, TextStyle, ViewStyle } from 'react-native';
+
+type NamedStyles<T> = {
+  [P in keyof T]: ViewStyle | TextStyle | ImageStyle;
+};
+
+const palette = {
+  gray: '#808080',
+  blue: '#007AFF',
+  darkGray: '#38434D',
+  white: '#FFFFFF',
+  black: '#000000',
+  purple: '#6366F1',
+};
+
+const theme = createTheme({
+  colors: {
+    ...palette
+  },
+  spacing: {
+    xs_4: 4,
+    s_8: 8,
+    sm_12: 12,
+    m_16: 16,
+    ml_24: 24,
+    l_32: 32,
+    xl_64: 64,
+  },
+  borderRadii: {
+    s_3: 3,
+    m_6: 6,
+    l_12: 12,
+    xl_24: 24,
+  },
+  textVariants: {
+    body: {
+      fontSize: 16,
+    },
+    title: { fontSize: 20, fontWeight: 'bold' },
+    large: {
+      fontSize: 36,
+    },
+    extra_large: {
+      fontSize: 64,
+      fontWeight: 'bold',
+    },
+    defaults: {
+      // We can define a default text variant here.
+    }
+  }
+});
+
+export const useTheme = () => {
+  return useRestyleTheme<Theme>();
+};
+
+export const makeStyles = <T extends NamedStyles<T> | NamedStyles<unknown>>(
+  styles: (theme: Theme) => T,
+) => {
+  return () => {
+    return styles(theme);
+  };
+};
+
+export type Theme = typeof theme;
+export default theme;

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -20,7 +20,8 @@ export const availablePackages = [
   'reactnavigation',
   'stylesheet',
   'supabase',
-  'tamagui'
+  'tamagui',
+  'restyle'
 ] as const;
 
 export type NavigationTypes = 'stack' | 'tabs' | 'drawer' | undefined;

--- a/cli/src/utilities/configureProjectFiles.ts
+++ b/cli/src/utilities/configureProjectFiles.ts
@@ -45,6 +45,19 @@ export function configureProjectFiles(
     files = [...files, ...tamaguiFiles];
   }
 
+  // add restyle files if needed
+  // modify base files with restyle specifications
+  if (stylingPackage?.name === 'restyle') {
+    const restyleFiles = [
+      'packages/restyle/theme/theme.ts.ejs',
+      'packages/restyle/theme/Box.tsx.ejs',
+      'packages/restyle/theme/Text.tsx.ejs',
+      'packages/restyle/theme/index.ts.ejs'
+    ];
+
+    files = [...files, ...restyleFiles];
+  }
+
   // add react navigation files if needed
   // modify base files with react navigation specifications
   if (navigationPackage?.name === 'react-navigation') {

--- a/cli/src/utilities/generateProjectFiles.ts
+++ b/cli/src/utilities/generateProjectFiles.ts
@@ -31,6 +31,8 @@ export function generateProjectFiles(
       target = target.replace('packages/tamagui/', '');
     } else if (stylingPackage?.name === 'nativewind') {
       target = target.replace('packages/nativewind/', '');
+    } else if (stylingPackage?.name === 'restyle') {
+      target = target.replace('packages/restyle/', '');
     }
 
     if (navigationPackage?.name === 'react-navigation') {

--- a/cli/src/utilities/runCLI.ts
+++ b/cli/src/utilities/runCLI.ts
@@ -73,7 +73,7 @@ export async function runCLI(toolbox: Toolbox, projectName: string): Promise<Cli
     type: 'select',
     name: 'stylingSelect',
     message: 'What would you like to use for styling?',
-    choices: ['Nativewind', 'Stylesheet', 'Tamagui (experimental)']
+    choices: ['Nativewind', 'Stylesheet', 'Tamagui (experimental)', 'Restyle']
   };
 
   const { stylingSelect } = await prompt.ask(askStyling);
@@ -84,6 +84,9 @@ export async function runCLI(toolbox: Toolbox, projectName: string): Promise<Cli
   } else if (stylingSelect === 'Tamagui (experimental)') {
     cliResults.packages.push({ name: 'tamagui', type: 'styling' });
     success(`You'll be styling with ease using Tamagui.`);
+  } else if (stylingSelect === 'Restyle') {
+    cliResults.packages.push({ name: 'restyle', type: 'styling' });
+    success(`You'll be styling with ease using Restyle.`);
   } else {
     cliResults.packages.push({ name: 'stylesheet', type: 'styling' });
     success(`Cool, you're using the default StyleSheet that comes with React Native.`);

--- a/cli/src/utilities/runCLI.ts
+++ b/cli/src/utilities/runCLI.ts
@@ -73,7 +73,7 @@ export async function runCLI(toolbox: Toolbox, projectName: string): Promise<Cli
     type: 'select',
     name: 'stylingSelect',
     message: 'What would you like to use for styling?',
-    choices: ['Nativewind', 'Stylesheet', 'Tamagui (experimental)', 'Restyle']
+    choices: ['Nativewind', 'Restyle', 'Stylesheet', 'Tamagui (experimental)']
   };
 
   const { stylingSelect } = await prompt.ask(askStyling);

--- a/cli/src/utilities/showHelp.ts
+++ b/cli/src/utilities/showHelp.ts
@@ -32,6 +32,7 @@ export function showHelp(info, highlight, warning) {
   highlight('   Styling Package Options');
   info('    	--nativewind      Use Nativewind for styling');
   info('    	--tamagui         Use Tamagui for styling');
+  info('    	--restyle         Use Restyle for styling');
   info('	--stylesheet      Use StyleSheet for styling');
   info('');
   highlight('   Opinionated Stacks');

--- a/docs/.astro/types.d.ts
+++ b/docs/.astro/types.d.ts
@@ -257,6 +257,13 @@ declare module "astro:content" {
         collection: "docs";
         data: InferEntrySchema<"docs">;
       } & { render(): Render[".md"] };
+      "en/usage/restyle.md": {
+        id: "en/usage/restyle.md";
+        slug: "en/usage/restyle";
+        body: string;
+        collection: "docs";
+        data: InferEntrySchema<"docs">;
+      } & { render(): Render[".md"] };
       "en/usage/supabase.md": {
         id: "en/usage/supabase.md";
         slug: "en/usage/supabase";

--- a/docs/src/components/Docs/FolderStructureDiagram.astro
+++ b/docs/src/components/Docs/FolderStructureDiagram.astro
@@ -73,6 +73,7 @@
         "tabs",
         "drawer",
         "tamagui",
+        "restyle",
         "supabase",
         "firebase",
       ];

--- a/docs/src/components/Docs/FolderStructureForm.astro
+++ b/docs/src/components/Docs/FolderStructureForm.astro
@@ -4,6 +4,7 @@ const options = {
   exporouter: "Expo Router",
   reactnavigation: "React Navigation",
   tamagui: "Tamagui",
+  restyle: "Restyle",
   supabase: "Supabase",
   firebase: "Firebase",
 };
@@ -33,6 +34,7 @@ const options = {
         "exporouter",
         "reactnavigation",
         "tamagui",
+        "restyle",
         "supabase",
         "firebase",
       ];

--- a/docs/src/content/docs/en/installation.md
+++ b/docs/src/content/docs/en/installation.md
@@ -68,6 +68,7 @@ bun create expo-stack myapp --expo-router --nativewind --bun
 | `--firebase`         | Use Firebase for authentication, initial configuration only                    |
 | `--supabase`         | Use Supabase for authentication, initial configuration only                    |
 | `--nativewind`       | Use Nativewind for styling                                                     |
-| `--stylesheet`       | Use StyleSheet for styling, used by default                                    |
 | `--tamagui`          | Use Tamagui for styling                                                        |
+| `--restyle`          | Use Restyle for styling                                                        |
+| `--stylesheet`       | Use StyleSheet for styling, used by default                                    |
 | `-i`, `--ignite`     | Initialize an opinionated starter using Infinite Red's Ignite                  |

--- a/docs/src/content/docs/en/usage/restyle.md
+++ b/docs/src/content/docs/en/usage/restyle.md
@@ -1,0 +1,8 @@
+---
+title: Restyle
+description: Using Restyle
+---
+
+The Restyle library provides a type-enforced system for building UI components in React Native with TypeScript. It's a library for building UI libraries, with themability as the core focus.
+
+This library assumes that the UI is built upon a design system that (at the very least) defines a set of colors and spacing constants that lays as a foundation. While the library acknowledges that there can be exceptions to the system by allowing any style to be overridden, it keeps the developer most productive when one-off values are kept to a minimum.

--- a/www/src/components/landing/stack/restyle.astro
+++ b/www/src/components/landing/stack/restyle.astro
@@ -1,0 +1,18 @@
+---
+
+---
+
+<a
+  target="_blank"
+  rel="noreferrer noopener"
+  href="https://shopify.github.io/restyle/"
+  class="group hover:no-underline relative overflow-hidden shadow-[inset_0_0_3rem_#06B6D444] hover:shadow-[inset_0_0_8rem_#06B6D444,0_0_2rem_#06B6D444] border-[#06B6D4]/80 hover:border-[#06B6D4] bg-[#06B6D4]/20 backdrop-blur-sm border text-cyan-200 p-4 sm:pr-20 flex-grow rounded-3xl flex flex-col items-start duration-500"
+>
+  <div
+    class="bg-[#06B6D4] group-hover:bg-[#26D6F4] duration-500 font-bold text-black rounded-full px-2 text-sm"
+  >
+    v2
+  </div>
+  <h1 class="text-2xl mt-2">Restyle</h1>
+  <span class="font-thin max-w-[24ch]">Themed UI in React-Native</span>
+</a>

--- a/www/src/components/landing/stack/stackSection.astro
+++ b/www/src/components/landing/stack/stackSection.astro
@@ -6,6 +6,7 @@ import Tamagui from "./tamagui.astro";
 import ExpoRouter from "./expoRouter.astro";
 import Supabase from "./supabase.astro";
 import Firebase from "./firebase.astro";
+import Restyle from "./restyle.astro";
 ---
 
 <div class="flex flex-wrap gap-4 pt-4 w-[90%] lg:w-[69%] 2xl:w-[60%]">
@@ -16,6 +17,7 @@ import Firebase from "./firebase.astro";
   <ExpoRouter />
   <Supabase />
   <Firebase />
+  <Restyle />
   <!-- to prevent fb being full width -->
   <div class="w-[55%] h-20"></div>
 </div>


### PR DESCRIPTION
## Description

I aim to integrate [Spotify's Restyle](https://github.com/Shopify/restyle) as a styling solution, as it is a simple and lightweight way to manage a theme in a React Native application.

> The Restyle library provides a type-enforced system for building UI components in React Native with TypeScript. It's a library for building UI libraries, with themability as the core focus.
> 
> This library assumes that the UI is built upon a design system that (at the very least) defines a set of colors and spacing constants that lays as a foundation. While the library acknowledges that there can be exceptions to the system by allowing any style to be overridden, it keeps the developer most productive when one-off values are kept to a minimum.

In addition to the core integration, I have added Restyle support to the landing page, documentation, and updated the **README** file to reflect these changes.

## How Has This Been Tested?

- I have generated a project with react-navigation (all variants) and expo-router
- add unit test for `--restyle`
- run the landing page
- run the documentation

