### PR TITLE
Rerouted createexpostack.com/docs to docs.createexpostack.com

### DIFF
--- a/www/src/config.ts
+++ b/www/src/config.ts
@@ -18,6 +18,8 @@ export const COMMUNITY_INVITE_URL = `https://discord.gg/XS9qS2mvTR`;
 
 export const DOCS_URL = `https://docs.createexpostack.com/`;
 
+export const MAIN_URL = `https://createexpostack.com/`;
+
 export const SPONSORS = [
   {
     id: 1,

--- a/www/src/pages/docs.astro
+++ b/www/src/pages/docs.astro
@@ -1,0 +1,6 @@
+---
+import { DOCS_URL } from "src/config";
+---
+
+<meta http-equiv="refresh" content={`0;url=${DOCS_URL}`} />
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Your title should include which part of the project your PR applies to (ex: [cli], [docs], [www]) -->

## Description
Navigating to createexpostack.com/docs reroutes to docs.createexpostack.com. Before it was showing a 404 page. 
For issue #172 

## How Has This Been Tested?

By putting  createexpostack.com/docs and seeing if it redirects to docs.createexpostack.com, and it did.

## Screenshots

Before  
![Screenshot 2024-01-17 at 1 27 13 PM](https://github.com/danstepanov/create-expo-stack/assets/39573679/7efc9145-d5be-406c-a36c-410aafdd8d40)

After
![Screenshot 2024-01-17 at 1 27 32 PM](https://github.com/danstepanov/create-expo-stack/assets/39573679/35beab47-6275-4e92-8e84-4abba04bf0cc)
