### PR TITLE
[cli] fix: added resolution/override for expo-modules-core to expo-router template

### DIFF
--- a/.changeset/ninety-shoes-tan.md
+++ b/.changeset/ninety-shoes-tan.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+added resolution/override for expo-modules-core to expo-router template

--- a/cli/src/templates/base/package.json.ejs
+++ b/cli/src/templates/base/package.json.ejs
@@ -97,10 +97,12 @@
   },
   <% if (props.navigationPackage?.name === 'expo-router') { %>
     "resolutions": {
-      "react-refresh": "~0.14.0"
+      "react-refresh": "~0.14.0",
+      "expo-modules-core": "~1.11.0"
     },
     "overrides": {
-      "react-refresh": "~0.14.0"
+      "react-refresh": "~0.14.0",
+      "expo-modules-core": "~1.11.0"
     },
   <% } else { %>
     "main": "node_modules/expo/AppEntry.js",


### PR DESCRIPTION
tackling #176 by adding expo-modules-core@1.11.0 to the resolution/overrides in the package.json when using expo router

## Description
 
I can't really get to the source of the issue. somehow when initializing a project with expo-router it will fail with the error code  described in the issue. It is fixed by using the expo-modules-core v1.11. 
But I don't really understand why this is not a problem in every project using expo 49 and expo-router v2 because expo 49 has expo-modules-core@1.5 as a dependency and expo-router@2.0.0 (and all minor version above 2.0.0) raise the error.
Maybe someone else has some idea? 

## Related Issue

#176

## How Has This Been Tested?

`bun run test --timeout=60000` in cli

`create-expo-stack my-expo-app --expo-router --nativewind`
`create-expo-stack my-expo-app --expo-router --stylesheet`
`create-expo-stack my-expo-app --nativewind`

for every configuration `cd my-expo-app && npm run ios` 

