### PR TITLE
[cli] fix: drop PascalCase req for ignite

### DIFF
--- a/.changeset/nice-dragons-call.md
+++ b/.changeset/nice-dragons-call.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+Ignite project names accept kebab case, forced PascalCase conversion has been removed

--- a/cli/src/commands/create-expo-stack.ts
+++ b/cli/src/commands/create-expo-stack.ts
@@ -26,8 +26,7 @@ const command: GluegunCommand = {
       filesystem: { exists, removeAsync },
       parameters: { first, options },
       print: { error, info, highlight, success, warning },
-      prompt,
-      strings: { pascalCase }
+      prompt
     } = toolbox;
 
     const printSomethingWentWrong = () => {
@@ -87,12 +86,6 @@ const command: GluegunCommand = {
         cliResults.projectName = first || DEFAULT_APP_NAME;
         const pathSegments = cliResults.projectName.split('/');
         cliResults.projectName = pathSegments.pop(); // get last segment as the project name
-      }
-
-      if (options.ignite) {
-        // right now Ignite requires PascalCase for the project name
-        // unsure why, will ask the team and then probably fix it upstream
-        cliResults.projectName = pascalCase(cliResults.projectName);
       }
 
       // Validate the project name; check if the directory already exists


### PR DESCRIPTION
## Description
- In an older Ignite version, only PascalCase project names were supported - that was enhanced with this Ignite PR: https://github.com/infinitered/ignite/pull/2534
- This PR removes that forced project name conversion
 
## Related Issue
n/a

## Motivation and Context
- Reduce code needed to maintain Ignite specifics
- More naming options for users

## How Has This Been Tested?
```
create-expo-stack ces-ignite --yarn
cd ces-ignite
yarn ios
```
