### PR TITLE
fix: missing import EditScreenInfo with nativewind config

### DIFF
--- a/cli/src/templates/packages/react-navigation/screens/home.tsx.ejs
+++ b/cli/src/templates/packages/react-navigation/screens/home.tsx.ejs
@@ -1,5 +1,6 @@
 <% if (props.stylingPackage?.name === 'nativewind') { %>
   import { Text, View } from 'react-native';
+  import EditScreenInfo from '../components/edit-screen-info';
 <% } else if (props.stylingPackage?.name === 'tamagui') { %>
   import { YStack, H2, Separator, Theme } from 'tamagui';
 <% } else if (props.stylingPackage?.name === 'restyle') { %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Your title should include which part of the project your PR applies to (ex: [cli], [docs], [www]) -->

## Description
When using nativewind, the home page will use `EditScreenInfo` but without its import
<!--- Describe your changes in detail -->
<!--- If your PR affects visual changes then please provide before and after images, gifs, or videos (below) -->

## Related Issue

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue linked above, you can remove this section -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
