### PR TITLE
[Docs] Made docs header logo navigate back to landing page

### DIFF
--- a/docs/src/components/Header/MainNav.tsx
+++ b/docs/src/components/Header/MainNav.tsx
@@ -1,9 +1,12 @@
 import React from "react";
-
+import { CREATE_EXPO_STACK_URL } from "@/consts";
 export default function MainNav() {
   return (
     <div className="mr-4  flex">
-      <a href="/" className="mr-6 flex items-center space-x-2">
+      <a
+        href={CREATE_EXPO_STACK_URL}
+        className="mr-6 flex items-center space-x-2"
+      >
         <div>
           <img
             className="block dark:hidden"

--- a/docs/src/consts.ts
+++ b/docs/src/consts.ts
@@ -24,6 +24,8 @@ export const EDIT_URL = `https://github.com/danstepanov/create-expo-stack`;
 
 export const COMMUNITY_INVITE_URL = `https://createexpostack.com/discord`;
 
+export const CREATE_EXPO_STACK_URL = `https://createexpostack.com/`;
+
 // See "Algolia" section of the README for more information.
 export const ALGOLIA = {
   indexName: "XXXXXXXXXX",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Your title should include which part of the project your PR applies to (ex: [cli], [docs], [www]) -->

## Description

In the docs, when you click Create Expo Stack, it goes back to the introduction page of the docs. But we want it to go back to the landing page. 

## Motivation and Context

To give the user the ability to go back to the landing page from the docs. 

## How Has This Been Tested?

Simple change in the link href, tested manually.
