### PR TITLE
[CLI] patch: bun + expo-router

### DIFF
--- a/cli/src/templates/base/package.json.ejs
+++ b/cli/src/templates/base/package.json.ejs
@@ -92,6 +92,10 @@
     "react-native": "0.73.2"
   },
   "devDependencies": {
+  <%# patch for this issue : https://github.com/expo/expo/issues/26641 %>
+  <% if (props.packageManager === "bun" && props.navigationPackage?.name === "expo-router") { %>
+	  "ajv": "^8.12.0",
+	<% } %>
     "@babel/core": "^7.20.0",
     "@types/react": "~18.2.14",
     "@typescript-eslint/eslint-plugin": "^6.7.2",


### PR DESCRIPTION
## Description

Patch for the following error when we use bun / expo-router:

```
$ expo start --ios
Error: Cannot find module 'ajv/dist/compile/codegen'
```

To reproduce
`npx create-expo-stack@2.4.2 delete-create --expo-router --drawer+tabs --restyle --bun`


## Related Issue

- https://github.com/expo/expo/issues/26641
- https://github.com/danstepanov/create-expo-stack/issues/204