### PR TITLE
[CLI] feat: add ios and android folder to the gitignore folder

### DIFF
--- a/.changeset/small-ways-add.md
+++ b/.changeset/small-ways-add.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+update the gitignore file

--- a/cli/src/templates/base/.gitignore.ejs
+++ b/cli/src/templates/base/.gitignore.ejs
@@ -16,6 +16,9 @@ expo-env.d.ts<% } %>
 <% if ((props.authenticationPackage?.name === "supabase") || (props.authenticationPackage?.name === "firebase")) { %># firebase/supabase
 .env<% } %>
 
+ios
+android
+
 # macOS
 .DS_Store
 


### PR DESCRIPTION
## Description

-  add ios and android folder to the gitignore folder

## Motivation and Context

- follow continuous native generation principle : https://docs.expo.dev/workflow/continuous-native-generation/
