### PR TITLE
chore: bump react-native

### DIFF
--- a/.changeset/dull-socks-sing.md
+++ b/.changeset/dull-socks-sing.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+Bump react-native to 0.73.4

--- a/cli/src/templates/base/package.json.ejs
+++ b/cli/src/templates/base/package.json.ejs
@@ -89,7 +89,7 @@
     "expo": "~50.0.5",
     "expo-status-bar": "~1.11.1",
     "react": "18.2.0",
-    "react-native": "0.73.2"
+    "react-native": "0.73.4"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
## Description
Resolved:
```
✔ Created native directories
› Using current versions instead of recommended react-native@0.73.4.
```
can be reproduced with this command : 
`npx create-expo-stack project --unistyles --bun`
`cd project && bun expo prebuild --clean`

## How Has This Been Tested?

```
npx expo-doctor
Need to install the following packages:
  expo-doctor@1.4.0
Ok to proceed? (y) y
✔ Check Expo config for common issues
✔ Check package.json for common issues
✔ Check dependencies for packages that should not be installed directly
✔ Check for common project setup issues
✔ Check for issues with metro config
✔ Check npm/ yarn versions
✔ Check Expo config (app.json/ app.config.js) schema
✔ Check for legacy global CLI installed locally
✔ Check that native modules do not use incompatible support packages
✔ Check that packages match versions required by installed Expo SDK
✔ Check that native modules use compatible support package versions for installed Expo SDK

Didn't find any issues with the project!
```