### PR TITLE
[cli] fix `npm >= 7` installation due to strict peer dependencies

### DIFF
--- a/.changeset/happy-parrots-protect.md
+++ b/.changeset/happy-parrots-protect.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+fix npm >= v7 installation due to strict peer dependency requirements of @react-native-async-storage/async-storage to react-native

--- a/cli/src/templates/base/package.json.ejs
+++ b/cli/src/templates/base/package.json.ejs
@@ -79,7 +79,7 @@
     <% } %>
 
 	<% if (props.authenticationPackage?.name === "supabase") { %>
-	    "@react-native-async-storage/async-storage": "1.18.2",
+	    "@react-native-async-storage/async-storage": "1.21.0",
 		"@supabase/supabase-js": "^2.38.4",
 		"react-native-url-polyfill": "^2.0.0",
 	<% } %>


### PR DESCRIPTION
## Description

`@react-native-async-storage/async-storage` has a strict peer dependency, i.e. a max version, of React Native it states it is compatible with. This isn't an issue for most package managers, just a warning, but for `npm >= 7` [peer dependencies are installed](https://stackoverflow.com/questions/66239691) and so their versions must match for the installation to succeed.

The newer version of `@react-native-async-storage/async-storage` recommended by the Expo CLI/bundler [updates the peer dependencies](https://github.com/react-native-async-storage/async-storage/pull/1029) and now allows any version of `react-native >=0.60 <1.0`, rather than setting a maximum version.

## Related Issue

[`npm` issue posted in Discord](https://discord.com/channels/1173879003191459860/1181066944368103454/1224717782164439048)

## Motivation and Context

`npm install` is broken without `npm install --legacy-peer-deps`, both of which break other things. This fixes plain `npm install`.

## How Has This Been Tested?

**Note:** You **must** selected Supabase as the auth provider in order for the offending package to be included in the generated project.

Run `npx create-expo-stack@latest` and update the `package.json` with the new version of `@react-native-async-storage/async-storage` (`1.21.0`), then running the following command to do everything the CLI would normally do if `npm install` originally succeeded during project generation:

`npm install && npm run format && git add package-lock.json && git commit -a --amend --no-edit`

You can also run the CLI from the git repository after pulling this branch.

Tested with Tamagui & NativeWind.

## Screenshots (if appropriate):

N/A