### PR TITLE
update plugins condition in app.json.ejs

### DIFF
--- a/.changeset/stale-eggs-yell.md
+++ b/.changeset/stale-eggs-yell.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+update the app.json EJS template to ensure that duplicate 'plugin' keys are avoided in the final app.json file.

--- a/cli/src/templates/base/app.json.ejs
+++ b/cli/src/templates/base/app.json.ejs
@@ -10,7 +10,12 @@
         "output": "static",
         "favicon": "./assets/favicon.png"
       },
-      "plugins": ["expo-router"],
+      "plugins": [
+      "expo-router",
+      <% if (props.internalizationPackage?.name === "i18next") { %>
+        "expo-localization"
+      <% } %>
+    ],
       "experiments": {
         "typedRoutes": true
         <% if (props.flags.importAlias) { %>
@@ -26,6 +31,11 @@
           "tsconfigPaths": true
         },
       <% } %> 
+      "plugins": [
+        <% if (props.internalizationPackage?.name === "i18next") { %>
+          "expo-localization"
+        <% } %>
+      ],
     <% } %>
     "orientation": "portrait",
     "icon": "./assets/icon.png",
@@ -47,11 +57,5 @@
         "backgroundColor": "#ffffff"
       }
     }
-    <% if (props.internalizationPackage?.name === "i18next") { %>
-    ,
-    "plugins": [
-      "expo-localization"
-    ]
-    <% } %> 
   }
 }


### PR DESCRIPTION
#update plugins condition in app.json.ejs

## Description
This pull request updates the plugins condition in `app.json.ejs` to avoid duplicated plugin keys in the final JSON output.

![Screenshot 2024-04-11 133828](https://github.com/danstepanov/create-expo-stack/assets/36106440/335ea834-7fb2-41ac-9f15-fa1bd3cd96c4)

## Motivation and Context

When generating the JSON output from `app.json.ejs`, it's important to ensure that there are no duplicated keys in the `plugins` section. This update addresses this issue by implementing some condition to avoid duplicated  `plugins`  key.

## How Has This Been Tested?

This change has been tested locally by updating `app.json.ejs` with the provided code changes and verifying that the JSON output does not contain duplicated plugin keys. Additionally, automated tests have been run to ensure that the code changes do not introduce any regressions.

