### PR TITLE
[cli] fix nativewind-ui android theme toggle icon from being cut off

### DIFF
--- a/cli/src/templates/packages/nativewindui/components/ThemeToggle.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/components/ThemeToggle.tsx.ejs
@@ -11,7 +11,7 @@ export function ThemeToggle() {
   return (
     <LayoutAnimationConfig skipEntering>
       <Animated.View
-        className="h-6 w-6 items-center justify-center"
+        className="items-center justify-center"
         key={`toggle-${colorScheme}`}
         entering={ZoomInRotate}>
         <Pressable


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Your title should include which part of the project your PR applies to (ex: [cli], [docs], [www]) -->

## Description

Change a className to prevent the Android toggle theme icon from being cut off.

<!--- Describe your changes in detail -->
<!--- If your PR affects visual changes then please provide before and after images, gifs, or videos (below) -->

## Related Issue

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue linked above, you can remove this section -->

## How Has This Been Tested?

Not in this repo. Since it only removes 2 tailwind utility classes from an element and it was tested in another app, I did not rebuild and install a new project using the cli. 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
