### PR TITLE
[cli] nativewind-ui use flashlist + change ts path alias + update color const

### DIFF
--- a/cli/src/templates/base/package.json.ejs
+++ b/cli/src/templates/base/package.json.ejs
@@ -22,6 +22,7 @@
     <% if (props.stylingPackage?.name === "nativewindui") { %>
       "@react-navigation/material-top-tabs": "^6.6.13",
       "@roninoss/icons": "^0.0.3",
+      "@shopify/flash-list": "1.6.3",
       "class-variance-authority": "^0.7.0",
       "clsx": "^2.1.0",
       "expo-dev-client": "~3.3.8",

--- a/cli/src/templates/base/tsconfig.json.ejs
+++ b/cli/src/templates/base/tsconfig.json.ejs
@@ -7,7 +7,7 @@
     "baseUrl": ".",
     "paths": {
       <% if (props.stylingPackage?.name === 'nativewindui') { %>
-        "@/*": [ "./*" ]
+        "~/*": [ "./*" ]
       <% } else { %>  
         <% if  (props.navigationPackage?.name === "expo-router" && props.flags.importAlias === true) { %>
         "~/*": ["*"]

--- a/cli/src/templates/packages/nativewindui/app/+not-found.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/app/+not-found.tsx.ejs
@@ -1,6 +1,6 @@
 import { Link, Stack } from 'expo-router';
 import { View } from 'react-native';
-import { Text } from '@/components/nativewind-ui/Text';
+import { Text } from '~/components/nativewind-ui/Text';
 
 export default function NotFoundScreen() {
   return (

--- a/cli/src/templates/packages/nativewindui/app/_layout.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/app/_layout.tsx.ejs
@@ -1,4 +1,4 @@
-import '@/global.css';
+import '~/global.css';
 import 'expo-dev-client';
 import { ThemeProvider as NavThemeProvider } from '@react-navigation/native';
 import { Icon } from '@roninoss/icons';
@@ -7,10 +7,10 @@ import { StatusBar } from 'expo-status-bar';
 import { Pressable, View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
-import { ThemeToggle } from '@/components/ThemeToggle';
-import { cn } from '@/lib/cn';
-import { useColorScheme } from '@/lib/useColorScheme';
-import { NAV_THEME } from '@/theme';
+import { ThemeToggle } from '~/components/ThemeToggle';
+import { cn } from '~/lib/cn';
+import { useColorScheme } from '~/lib/useColorScheme';
+import { NAV_THEME } from '~/theme';
 
 export {
   // Catch any errors thrown by the Layout component.

--- a/cli/src/templates/packages/nativewindui/app/bottom-tabs/_layout.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/app/bottom-tabs/_layout.tsx.ejs
@@ -1,4 +1,4 @@
-import { ThemeToggle } from '@/components/ThemeToggle';
+import { ThemeToggle } from '~/components/ThemeToggle';
 import { Icon } from '@roninoss/icons';
 import { Tabs } from 'expo-router';
 import { View } from 'react-native';

--- a/cli/src/templates/packages/nativewindui/app/drawer/_layout.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/app/drawer/_layout.tsx.ejs
@@ -1,5 +1,5 @@
-import { ThemeToggle } from '@/components/ThemeToggle';
-import { useColorScheme } from '@/lib/useColorScheme';
+import { ThemeToggle } from '~/components/ThemeToggle';
+import { useColorScheme } from '~/lib/useColorScheme';
 import { Drawer } from 'expo-router/drawer';
 import { View } from 'react-native';
 

--- a/cli/src/templates/packages/nativewindui/app/index.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/app/index.tsx.ejs
@@ -1,13 +1,20 @@
+import { FlashList } from '@shopify/flash-list';
+import { cssInterop } from 'nativewind';
 import * as React from 'react';
-import { Button as RNButton, ButtonProps, FlatList, Linking, View } from 'react-native';
+import { Button as RNButton, ButtonProps, Linking, View } from 'react-native';
 
-import { Text } from '@/components/nativewind-ui/Text';
-import { useColorScheme } from '@/lib/useColorScheme';
-import { useHeaderSearchBar } from '@/lib/useHeaderSearchBar';
+import { Text } from '~/components/nativewind-ui/Text';
+import { useColorScheme } from '~/lib/useColorScheme';
+import { useHeaderSearchBar } from '~/lib/useHeaderSearchBar';
+
+cssInterop(FlashList, {
+  className: 'style',
+  contentContainerClassName: 'contentContainerStyle',
+});
 
 function DefaultButton({ color, ...props }: ButtonProps) {
   const { colors } = useColorScheme();
-  return <RNButton color={color ?? colors.blue} {...props} />;
+  return <RNButton color={color ?? colors.primary} {...props} />;
 }
 
 export default function Screen() {
@@ -17,40 +24,57 @@ export default function Screen() {
     ? COMPONENTS.filter((c) => c.name.toLowerCase().includes(searchValue.toLowerCase()))
     : COMPONENTS;
 
-  const screens = searchValue
-    ? FULL_SCREEN_COMPONENTS.filter((c) => c.name.toLowerCase().includes(searchValue.toLowerCase()))
-    : FULL_SCREEN_COMPONENTS;
+  if (data.length === 0) {
+    return (
+      <View className='flex-1 justify-center items-center px-4'>
+        <Text variant='title3' className='text-center font-bold pb-1'>
+          {searchValue.length === 0
+            ? 'No Components Installed'
+            : 'No Components Found'}
+        </Text>
+        <Text color='tertiary' variant='body' className='text-center pb-4'>
+          You can install any of the free components from the NativeWindUI
+          website.
+        </Text>
+        <DefaultButton
+          title='Open NativeWindUI'
+          onPress={() => Linking.openURL('https://nativewindui.com')}
+        />
+      </View>
+    );
+  }
 
   return (
-    <FlatList
+    <FlashList
       contentInsetAdjustmentBehavior="automatic"
+      keyboardShouldPersistTaps="handled"
       data={data}
-      contentContainerClassName="flex flex-1 py-4 items-center justify-center"
+      estimatedItemSize={200}
+      contentContainerClassName="py-4"
       extraData={searchValue}
       removeClippedSubviews={false} // used for selecting text on android
-      keyExtractor={(item) => item.name}
-      ItemSeparatorComponent={() => <View className="p-2" />}
-      renderItem={({ item }) => {
-        return (
-          <Card title={item.name}>
-            <item.component />
-          </Card>
-        );
-      }}
-      ListEmptyComponent={() => {
-        return (
-          <View className='px-4'>
-            <Text variant="title3" className="text-center font-bold">
-              No Components Installed
-            </Text>
-            <Text color="tertiary" variant="body" className="text-center pb-4">
-              You can install any of the free components from the NativeWindUI website.
-            </Text>
-            <DefaultButton title="Open NativeWindUI" onPress={() => Linking.openURL('https://nativewindui.com')} />
-          </View>
-        )
-      }}
+      keyExtractor={keyExtractor}
+      ItemSeparatorComponent={renderItemSeparator}
+      renderItem={renderItem}
     />
+  );
+}
+
+type ComponentItem = { name: string; component: () => React.JSX.Element };
+
+function keyExtractor(item: ComponentItem) {
+  return item.name;
+}
+
+function renderItemSeparator() {
+  return <View className='p-2' />;
+}
+
+function renderItem({ item }: { item: ComponentItem }) {
+  return (
+    <Card title={item.name}>
+      <item.component />
+    </Card>
   );
 }
 
@@ -65,20 +89,5 @@ function Card({ children, title }: { children: React.ReactNode; title: string })
   );
 }
 
-const COMPONENTS = [
-] as const;
+const COMPONENTS: ComponentItem[] = [];
 
-const FULL_SCREEN_COMPONENTS = [
-  {
-    name: 'Drawer Navigation',
-    href: '/drawer/',
-  },
-  {
-    name: 'Bottom Tabs Navigation',
-    href: '/bottom-tabs/',
-  },
-  {
-    name: 'Top Tabs Navigation',
-    href: '/top-tabs/',
-  },
-] as const;

--- a/cli/src/templates/packages/nativewindui/app/modal.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/app/modal.tsx.ejs
@@ -1,4 +1,4 @@
-import { Text } from '@/components/nativewind-ui/Text';
+import { Text } from '~/components/nativewind-ui/Text';
 import { Link } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useColorScheme } from 'nativewind';

--- a/cli/src/templates/packages/nativewindui/app/top-tabs/_layout.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/app/top-tabs/_layout.tsx.ejs
@@ -1,4 +1,4 @@
-import { useColorScheme } from '@/lib/useColorScheme';
+import { useColorScheme } from '~/lib/useColorScheme';
 import type {
   MaterialTopTabNavigationEventMap,
   MaterialTopTabNavigationOptions,
@@ -43,7 +43,7 @@ export default function TopTabsLayout() {
     <TopTabs
       initialRouteName='index'
       screenOptions={{
-        tabBarActiveTintColor: colors.blue,
+        tabBarActiveTintColor: colors.primary,
         tabBarInactiveTintColor: 'grey',
         tabBarLabelStyle: {
           fontSize: 14,
@@ -51,7 +51,7 @@ export default function TopTabsLayout() {
           fontWeight: 'bold',
         },
         tabBarIndicatorStyle: {
-          backgroundColor: colors.blue,
+          backgroundColor: colors.primary,
         },
         tabBarScrollEnabled: true,
         tabBarItemStyle: { width: width / SCREENS.length },

--- a/cli/src/templates/packages/nativewindui/app/top-tabs/following.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/app/top-tabs/following.tsx.ejs
@@ -1,4 +1,4 @@
-import { Text } from '@/components/nativewind-ui/Text';
+import { Text } from '~/components/nativewind-ui/Text';
 import { View } from 'react-native';
 
 export default function FollowingScreen() {

--- a/cli/src/templates/packages/nativewindui/app/top-tabs/index.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/app/top-tabs/index.tsx.ejs
@@ -1,4 +1,4 @@
-import { Text } from '@/components/nativewind-ui/Text';
+import { Text } from '~/components/nativewind-ui/Text';
 import { View } from 'react-native';
 
 export default function ForYouScreen() {

--- a/cli/src/templates/packages/nativewindui/app/top-tabs/my-group.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/app/top-tabs/my-group.tsx.ejs
@@ -1,5 +1,5 @@
 import { View } from 'react-native';
-import { Text } from '@/components/nativewind-ui/Text';
+import { Text } from '~/components/nativewind-ui/Text';
 
 export default function MyGroupScreen() {
   return (

--- a/cli/src/templates/packages/nativewindui/components/ThemeToggle.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/components/ThemeToggle.tsx.ejs
@@ -2,9 +2,9 @@ import { Icon } from '@roninoss/icons';
 import { Appearance, Pressable, View } from 'react-native';
 import Animated, { LayoutAnimationConfig, ZoomInRotate } from 'react-native-reanimated';
 
-import { cn } from '@/lib/cn';
-import { useColorScheme } from '@/lib/useColorScheme';
-import { COLORS } from '@/theme/colors';
+import { cn } from '~/lib/cn';
+import { useColorScheme } from '~/lib/useColorScheme';
+import { COLORS } from '~/theme/colors';
 
 export function ThemeToggle() {
   const { colorScheme, toggleColorScheme } = useColorScheme();

--- a/cli/src/templates/packages/nativewindui/components/nativewind-ui/Text.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/components/nativewind-ui/Text.tsx.ejs
@@ -3,7 +3,7 @@ import { cssInterop } from 'nativewind';
 import * as React from 'react';
 import { UITextView } from 'react-native-uitextview';
 
-import { cn } from '@/lib/cn';
+import { cn } from '~/lib/cn';
 
 cssInterop(UITextView, { className: 'style' });
 

--- a/cli/src/templates/packages/nativewindui/lib/useColorScheme.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/lib/useColorScheme.tsx.ejs
@@ -1,6 +1,6 @@
 import { useColorScheme as useNativewindColorScheme } from 'nativewind';
 
-import { COLORS } from '@/theme/colors';
+import { COLORS } from '~/theme/colors';
 
 export function useColorScheme() {
   const { colorScheme, setColorScheme, toggleColorScheme } = useNativewindColorScheme();

--- a/cli/src/templates/packages/nativewindui/lib/useHeaderSearchBar.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/lib/useHeaderSearchBar.tsx.ejs
@@ -1,4 +1,4 @@
-import { COLORS } from '@/theme/colors';
+import { COLORS } from '~/theme/colors';
 import { useNavigation } from 'expo-router';
 import * as React from 'react';
 import { SearchBarProps } from 'react-native-screens';
@@ -15,7 +15,7 @@ export function useHeaderSearchBar(props: SearchBarProps = {}) {
         placeholder: 'Search...',
         barTintColor: colorScheme === 'dark' ? COLORS.black : COLORS.white,
         textColor: colors.foreground,
-        tintColor: colors.blue,
+        tintColor: colors.primary,
         headerIconColor: colors.foreground,
         hintTextColor: colors.grey,
         hideWhenScrolling: false,

--- a/cli/src/templates/packages/nativewindui/theme/colors.ts.ejs
+++ b/cli/src/templates/packages/nativewindui/theme/colors.ts.ejs
@@ -14,8 +14,8 @@ const IOS_SYSTEM_COLORS = {
     foreground: 'rgb(0, 0, 0)',
     root: 'rgb(255, 255, 255)',
     card: 'rgb(255, 255, 255)',
-    red: 'rgb(255, 56, 43)',
-    blue: 'rgb(0, 123, 254)',
+    destructive: 'rgb(255, 56, 43)',
+    primary: 'rgb(0, 123, 254)',
   },
   dark: {
     grey6: 'rgb(21, 21, 24)',
@@ -28,8 +28,8 @@ const IOS_SYSTEM_COLORS = {
     foreground: 'rgb(255, 255, 255)',
     root: 'rgb(0, 0, 0)',
     card: 'rgb(28, 28, 30)',
-    red: 'rgb(254, 67, 54)',
-    blue: 'rgb(3, 133, 255)',
+    destructive: 'rgb(254, 67, 54)',
+    primary: 'rgb(3, 133, 255)',
   },
 } as const;
 
@@ -47,8 +47,8 @@ const ANDROID_COLORS = {
     foreground: 'rgb(0, 0, 0)',
     root: 'rgb(255, 255, 255)',
     card: 'rgb(255, 255, 255)',
-    red: 'rgb(186, 26, 26)',
-    blue: 'rgb(0, 112, 233)',
+    destructive: 'rgb(186, 26, 26)',
+    primary: 'rgb(0, 112, 233)',
   },
   dark: {
     grey6: 'rgb(16, 19, 27)',
@@ -61,8 +61,8 @@ const ANDROID_COLORS = {
     foreground: 'rgb(255, 255, 255)',
     root: 'rgb(0, 0, 0)',
     card: 'rgb(16, 19, 27)',
-    red: 'rgb(147, 0, 10)',
-    blue: 'rgb(3, 133, 255)',
+    destructive: 'rgb(147, 0, 10)',
+    primary: 'rgb(3, 133, 255)',
   },
 } as const;
 

--- a/cli/src/templates/packages/nativewindui/theme/index.ts.ejs
+++ b/cli/src/templates/packages/nativewindui/theme/index.ts.ejs
@@ -8,8 +8,8 @@ const NAV_THEME: { light: Theme; dark: Theme } = {
       background: COLORS.light.background,
       border: COLORS.light.grey5,
       card: COLORS.light.card,
-      notification: COLORS.light.red,
-      primary: COLORS.light.blue, // BRAND COLOR
+      notification: COLORS.light.destructive,
+      primary: COLORS.light.primary,
       text: COLORS.black,
     },
   },
@@ -19,8 +19,8 @@ const NAV_THEME: { light: Theme; dark: Theme } = {
       background: COLORS.dark.background,
       border: COLORS.dark.grey5,
       card: COLORS.dark.grey6,
-      notification: COLORS.dark.red,
-      primary: COLORS.dark.blue, // BRAND COLOR
+      notification: COLORS.dark.destructive,
+      primary: COLORS.dark.primary,
       text: COLORS.white,
     },
   },

--- a/cli/src/utilities/configureProjectFiles.ts
+++ b/cli/src/utilities/configureProjectFiles.ts
@@ -58,7 +58,6 @@ export function configureProjectFiles(
     'packages/nativewindui/app/modal.tsx.ejs',
     'packages/nativewindui/components/nativewind-ui/Text.tsx.ejs',
     'packages/nativewindui/components/ThemeToggle.tsx.ejs',
-    'packages/nativewindui/components/nativewind-ui/Toggle.tsx.ejs',
     'packages/nativewindui/lib/useColorScheme.tsx.ejs',
     'packages/nativewindui/lib/useHeaderSearchBar.tsx.ejs',
     'packages/nativewindui/lib/cn.ts.ejs',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Your title should include which part of the project your PR applies to (ex: [cli], [docs], [www]) -->



## Description

<!--- Describe your changes in detail -->
<!--- If your PR affects visual changes then please provide before and after images, gifs, or videos (below) -->

- Centers the "empty list component" *
_*(**see recording below** as centering is tricky with a "largeTitle" in the header. It is completely centered when the search input is focused and a little higher than center otherwise. Of all the options, I think this one looks the best and it was the easiest to implement so that is looks good on all platforms and all devices.)_
- Replace `flatlist` with shopify's `flashlist`
- Change the typescript path alias to ‘~/‘ instead of ‘@/‘
- Update the color constant of "blue" to "primary" and "red" to "destructive"

## Related Issue

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue linked above, you can remove this section -->

For upcoming NativeWindUI template:

- Prevent the use of FlatList as there is no reason to use it anymore
- Use the default type alias used by recommended expo cli `npx create-expo-app@latest --template tabs@50`, other CES templates and react-native-reusables
- Update the color constant to facilitate users that want to add their own primary and destructive colors.

## How Has This Been Tested?

Locally with bun on iOS.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

https://github.com/danstepanov/create-expo-stack/assets/63797719/6b7a5b62-a187-4125-9583-ebc7df964e5c

