### PR TITLE
[cli] nativewind-ui adjustments

### DIFF
--- a/cli/src/templates/base/app.json.ejs
+++ b/cli/src/templates/base/app.json.ejs
@@ -39,7 +39,11 @@
     <% } %>
     "orientation": "portrait",
     "icon": "./assets/icon.png",
-    "userInterfaceStyle": "light",
+    <% if (props.stylingPackage?.name === "nativewindui") { %>
+    "userInterfaceStyle": "automatic",
+     <% } else { %>
+     "userInterfaceStyle": "light",
+    <% } %>
     "splash": {
       "image": "./assets/splash.png",
       "resizeMode": "contain",

--- a/cli/src/templates/base/package.json.ejs
+++ b/cli/src/templates/base/package.json.ejs
@@ -26,18 +26,18 @@
       "clsx": "^2.1.0",
       "expo-dev-client": "~3.3.8",
       "tailwind-merge": "^2.2.1",
-      <% if (props.stylingPackage?.options.selectedComponents.includes('actionable-text')) { %>
+      <% if (props.stylingPackage?.options.selectedComponents.includes('selectable-text')) { %>
       "react-native-uitextview": "^1.1.4",
       <% } %>
       "react-native-pager-view": "6.2.3",
       <% if (props.stylingPackage?.options.selectedComponents.includes('date-picker')) { %>
-        "@react-native-community/datetimepicker": "7.6.1",
+        "@react-native-community/datetimepicker": "7.7.0",
       <% } %>
       <% if (props.stylingPackage?.options.selectedComponents.includes('segmented-control')) { %>
         "@react-native-segmented-control/segmented-control": "2.4.1",
       <% } %>
       <% if (props.stylingPackage?.options.selectedComponents.includes('picker')) { %>
-        "@react-native-picker/picker": "^2.6.1",
+        "@react-native-picker/picker": "2.6.1",
       <% } %>
       <% if (props.stylingPackage?.options.selectedComponents.includes('bottom-sheet')) { %>
         "@gorhom/bottom-sheet": "^4",

--- a/cli/src/templates/packages/nativewindui/app/_layout.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/app/_layout.tsx.ejs
@@ -11,7 +11,9 @@ import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import { Link, Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { Pressable, View } from 'react-native';
+<% if (props.stylingPackage?.options.selectedComponents.includes('bottom-sheet')) { %>
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+<% } %>
 
 import { ThemeToggle } from '~/components/nativewind-ui/ThemeToggle';
 import { cn } from '~/lib/cn';
@@ -32,8 +34,8 @@ export default function RootLayout() {
         key={`root-status-bar-${isDarkColorScheme ? 'light' : 'dark'}`}
         style={isDarkColorScheme ? 'light' : 'dark'}
       />
+       <% if (props.stylingPackage?.options.selectedComponents.includes('bottom-sheet')) { %>
       <GestureHandlerRootView style={{ flex: 1 }}>
-        <% if (props.stylingPackage?.options.selectedComponents.includes('bottom-sheet')) { %>
         <BottomSheetModalProvider>
         <% } %>
         <% if (props.stylingPackage?.options.selectedComponents.includes('action-sheet')) { %>
@@ -50,8 +52,8 @@ export default function RootLayout() {
         <% } %>
         <% if (props.stylingPackage?.options.selectedComponents.includes('bottom-sheet')) { %>
         </BottomSheetModalProvider>
-        <% } %>
       </GestureHandlerRootView>
+      <% } %>
     </>
   );
 }
@@ -80,13 +82,6 @@ function SettingsIcon() {
     </Link>
   );
 }
-
-const TOP_TABS_OPTIONS = {
-  title: 'Top Tabs',
-  headerShadowVisible: false,
-  headerBackTitle: 'Back',
-  headerRight: () => <ThemeToggle />,
-} as const;
 
 const MODAL_OPTIONS = {
   presentation: 'modal',

--- a/cli/src/templates/packages/nativewindui/app/index.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/app/index.tsx.ejs
@@ -16,8 +16,10 @@ import {
   <% if (props.stylingPackage?.options.selectedComponents.includes('activity-view')) { %>
   Share,
   <% } %>
+  useWindowDimensions,
   View,
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 <% if (props.stylingPackage?.options.selectedComponents.includes('action-sheet')) { %>
 import { useActionSheet } from '@expo/react-native-action-sheet';
 <% } %>
@@ -75,7 +77,7 @@ function DefaultButton({ color, ...props }: ButtonProps) {
 }
 
 export default function Screen() {
-  const searchValue = useHeaderSearchBar();
+  const searchValue = useHeaderSearchBar({ hideWhenScrolling: COMPONENTS.length === 0 });
 
   const data = searchValue
     ? COMPONENTS.filter((c) => c.name.toLowerCase().includes(searchValue.toLowerCase()))
@@ -88,30 +90,28 @@ export default function Screen() {
       data={data}
       estimatedItemSize={200}
       contentContainerClassName="py-4"
-      centerContent={data.length === 0}
       extraData={searchValue}
+      <% if (props.stylingPackage?.options.selectedComponents.includes('selectable-text')) { %>
       removeClippedSubviews={false} // used for selecting text on android
+      <% } %>
       keyExtractor={keyExtractor}
       ItemSeparatorComponent={renderItemSeparator}
       renderItem={renderItem}
-      ListEmptyComponent={ListEmptyComponent}
+      ListEmptyComponent={COMPONENTS.length === 0 ? ListEmptyComponent : undefined}
     />
   );
 }
 
-const SEARCH_BAR_HEIGHT = 52;
-
 function ListEmptyComponent() {
   const insets = useSafeAreaInsets();
+  const dimensions = useWindowDimensions();
   const headerHeight = useHeaderHeight();
   const { colors } = useColorScheme();
+  const height = dimensions.height - headerHeight - insets.bottom - insets.top;
+
   return (
-    <>
-      {Platform.OS === 'ios' && (
-        <View style={{ height: headerHeight + SEARCH_BAR_HEIGHT + insets.top - insets.bottom }} />
-      )}
-      <View className='flex-1 items-center justify-center px-12 gap-1'>
-        <Icon name='folder-plus-outline' size={42} color={colors.grey} />
+    <View style={{ height }} className="flex-1 items-center justify-center gap-1 px-12">
+      <Icon name="file-plus-outline" size={42} color={colors.grey} />
         <Text variant='title3' className='pb-1 text-center font-semibold'>
           No Components Installed
         </Text>
@@ -127,11 +127,10 @@ function ListEmptyComponent() {
           {' website.'}
         </Text>
       </View>
-    </>
   );
 }
 
-type ComponentItem = { name: string; component: () => React.JSX.Element };
+type ComponentItem = { name: string; component: React.FC };
 
 function keyExtractor(item: ComponentItem) {
   return item.name;
@@ -164,7 +163,7 @@ const COMPONENTS: ComponentItem[] = [
   <% if (props.stylingPackage?.options.selectedComponents.includes('picker')) { %>
   {
     name: 'Picker',
-    component: () => {
+    component: function PickerExample() {
       const { colors } = useColorScheme();
       const [picker, setPicker] = React.useState('blue');
       return (
@@ -204,7 +203,7 @@ const COMPONENTS: ComponentItem[] = [
   <% if (props.stylingPackage?.options.selectedComponents.includes('date-picker')) { %>
   {
     name: 'Date Picker',
-    component: () => {
+    component: function DatePickerExample() {
       const [date, setDate] = React.useState(new Date());
       return (
         <View className='items-center'>
@@ -223,7 +222,7 @@ const COMPONENTS: ComponentItem[] = [
   <% if (props.stylingPackage?.options.selectedComponents.includes('segmented-control')) { %>
   {
     name: 'Segmented Controls',
-    component: () => {
+    component: function SegmentedControlsExample() {
       const [segment, setSegment] = React.useState(0);
       return (
         <SegmentedControl
@@ -240,7 +239,7 @@ const COMPONENTS: ComponentItem[] = [
   <% if (props.stylingPackage?.options.selectedComponents.includes('slider')) { %>
   {
     name: 'Slider',
-    component: () => {
+    component: function SliderExample() {
       const [sliderValue, setSliderValue] = React.useState(0.5);
       return <Slider value={sliderValue} onValueChange={setSliderValue} />;
     },
@@ -249,7 +248,7 @@ const COMPONENTS: ComponentItem[] = [
   <% if (props.stylingPackage?.options.selectedComponents.includes('toggle')) { %>
   {
     name: 'Toggle',
-    component: () => {
+    component: function ToggleExample() {
       const [switchValue, setSwitchValue] = React.useState(true);
       return (
         <View className='items-center'>
@@ -262,7 +261,7 @@ const COMPONENTS: ComponentItem[] = [
   <% if (props.stylingPackage?.options.selectedComponents.includes('context-menu')) { %>
   {
     name: 'Context Menu',
-    component: () => {
+    component: function ContextMenuExample() {
       const [isChecked, setIsChecked] = React.useState(true);
       return (
         <View>
@@ -303,9 +302,9 @@ const COMPONENTS: ComponentItem[] = [
   <% if (props.stylingPackage?.options.selectedComponents.includes('dropdown-menu')) { %>
   {
     name: 'Dropdown Menu',
-    component: () => {
+    component: function DropdownMenuExample() {
       const { colors } = useColorScheme();
-      const [menu, setMenu] = React.useState<'blue' | 'red'>('blue');
+      const [menu, setMenu] = React.useState<'primary' | 'destructive'>('primary');
 
       return (
         <View className='items-center'>
@@ -326,24 +325,24 @@ const COMPONENTS: ComponentItem[] = [
             </DropdownMenu.Trigger>
             <DropdownMenu.Content>
               <DropdownMenu.CheckboxItem
-                key='red'
-                value={menu === 'red'}
+                key='destructive'
+                value={menu === 'destructive'}
                 onValueChange={() => {
-                  setMenu('red');
+                  setMenu('destructive');
                 }}
               >
                 <DropdownMenu.ItemIndicator />
-                <DropdownMenu.ItemTitle children='red' />
+                <DropdownMenu.ItemTitle children='destructive' />
               </DropdownMenu.CheckboxItem>
               <DropdownMenu.CheckboxItem
-                key='blue'
-                value={menu === 'blue'}
+                key='primary'
+                value={menu === 'primary'}
                 onValueChange={() => {
-                  setMenu('blue');
+                  setMenu('primary');
                 }}
               >
                 <DropdownMenu.ItemIndicator />
-                <DropdownMenu.ItemTitle children='blue' />
+                <DropdownMenu.ItemTitle children='primary' />
               </DropdownMenu.CheckboxItem>
             </DropdownMenu.Content>
           </DropdownMenu.Root>
@@ -355,7 +354,7 @@ const COMPONENTS: ComponentItem[] = [
   <% if (props.stylingPackage?.options.selectedComponents.includes('progress-indicator')) { %>
   {
     name: 'Progress Indicator',
-    component: () => {
+    component: function ProgressIndicatorExample() {
       const [progress, setProgress] = React.useState(13);
       let id: ReturnType<typeof setInterval> | null = null;
       React.useEffect(() => {
@@ -379,7 +378,7 @@ const COMPONENTS: ComponentItem[] = [
   <% if (props.stylingPackage?.options.selectedComponents.includes('activity-indicator')) { %>
   {
     name: 'Activity Indicator',
-    component: () => {
+    component: function ActivityIndicatorExample() {
       return (
         <View className='p-4 items-center'>
           <ActivityIndicator />
@@ -391,14 +390,14 @@ const COMPONENTS: ComponentItem[] = [
   <% if (props.stylingPackage?.options.selectedComponents.includes('alert')) { %>
   {
     name: 'Alert',
-    component: () => {
+    component: function AlertExample() {
       const { colors } = useColorScheme();
       return (
         <View className='items-center'>
           <DefaultButton
-            color={colors.red}
+            color={colors.destructive}
             onPress={() => {
-              if (Platform.OS == 'ios') {
+              if (Platform.OS === 'ios') {
                 Alert.prompt(
                   'Delete account?',
                   'Enter your password to delete your account.',
@@ -447,7 +446,7 @@ const COMPONENTS: ComponentItem[] = [
   <% if (props.stylingPackage?.options.selectedComponents.includes('action-sheet')) { %>
   {
     name: 'Action Sheet',
-    component: () => {
+    component: function ActionSheetExample() {
       const { colorScheme, colors } = useColorScheme();
       const { showActionSheetWithOptions } = useActionSheet();
       return (
@@ -497,49 +496,51 @@ const COMPONENTS: ComponentItem[] = [
   <% if (props.stylingPackage?.options.selectedComponents.includes('text')) { %>
   {
     name: 'Text',
-    component: () => (
-      <View className='gap-2'>
-        <Text variant='largeTitle' className='text-center'>
-          Large Title
-        </Text>
-        <Text variant='title1' className='text-center'>
-          Title 1
-        </Text>
-        <Text variant='title2' className='text-center'>
-          Title 2
-        </Text>
-        <Text variant='title3' className='text-center'>
-          Title 3
-        </Text>
-        <Text variant='heading' className='text-center'>
-          Heading
-        </Text>
-        <Text variant='body' className='text-center'>
-          Body
-        </Text>
-        <Text variant='callout' className='text-center'>
-          Callout
-        </Text>
-        <Text variant='subhead' className='text-center'>
-          Subhead
-        </Text>
-        <Text variant='footnote' className='text-center'>
-          Footnote
-        </Text>
-        <Text variant='caption1' className='text-center'>
-          Caption 1
-        </Text>
-        <Text variant='caption2' className='text-center'>
-          Caption 2
-        </Text>
-      </View>
-    ),
+    component: function TextExample() {
+      return (
+        <View className='gap-2'>
+          <Text variant='largeTitle' className='text-center'>
+            Large Title
+          </Text>
+          <Text variant='title1' className='text-center'>
+            Title 1
+          </Text>
+          <Text variant='title2' className='text-center'>
+            Title 2
+          </Text>
+          <Text variant='title3' className='text-center'>
+            Title 3
+          </Text>
+          <Text variant='heading' className='text-center'>
+            Heading
+          </Text>
+          <Text variant='body' className='text-center'>
+            Body
+          </Text>
+          <Text variant='callout' className='text-center'>
+            Callout
+          </Text>
+          <Text variant='subhead' className='text-center'>
+            Subhead
+          </Text>
+          <Text variant='footnote' className='text-center'>
+            Footnote
+          </Text>
+          <Text variant='caption1' className='text-center'>
+            Caption 1
+          </Text>
+          <Text variant='caption2' className='text-center'>
+            Caption 2
+          </Text>
+        </View>
+      );
+    },
   },
   <% } %>
-  <% if (props.stylingPackage?.options.selectedComponents.includes('actionable-text')) { %>
+  <% if (props.stylingPackage?.options.selectedComponents.includes('selectable-text')) { %>
   {
     name: 'Actionable Text',
-    component: () => {
+    component: function SelectableTextExample() {
       return (
         <Text uiTextView selectable>
           Long press or double press this text
@@ -551,61 +552,90 @@ const COMPONENTS: ComponentItem[] = [
   <% if (props.stylingPackage?.options.selectedComponents.includes('ratings-indicator')) { %>
   {
     name: 'Ratings Indicator',
-    component: () => (
-      <View className='items-center'>
-        <DefaultButton
-          color='orange'
-          onPress={async () => {
-            if (await StoreReview.hasAction()) {
-              StoreReview.requestReview();
-            }
-            if (Platform.OS === 'android') {
-              Alert.alert(
-                'Android Demo',
-                'Store review is not available for Android demo'
-              );
-            }
-          }}
-          title='Rate this app'
-        />
-      </View>
-    ),
+    component: function RatingsIndicatorExample() {
+      React.useEffect(() => {
+        async function showRequestReview() {
+          if (await StoreReview.hasAction()) {
+            StoreReview.requestReview();
+          }
+        }
+        const timeout = setTimeout(() => {
+          showRequestReview();
+          wasAskedRef.current = true;
+        }, 1000);
+
+        return () => clearTimeout(timeout);
+      }, []);
+
+      return (
+        <View className="gap-3">
+          <Text className="pb-2 text-center font-semibold">Please follow the guidelines.</Text>
+          <View className="flex-row">
+            <Text className="w-6 text-center text-muted-foreground">·</Text>
+            <View className="flex-1">
+              <Text variant="caption1" className="text-muted-foreground">
+                Don't call StoreReview.requestReview() from a button
+              </Text>
+            </View>
+          </View>
+          <View className="flex-row">
+            <Text className="w-6 text-center text-muted-foreground">·</Text>
+            <View className="flex-1">
+              <Text variant="caption1" className="text-muted-foreground">
+                Don't request a review when the user is doing something time sensitive.
+              </Text>
+            </View>
+          </View>
+          <View className="flex-row">
+            <Text className="w-6 text-center text-muted-foreground">·</Text>
+            <View className="flex-1">
+              <Text variant="caption1" className="text-muted-foreground">
+                Don't ask the user any questions before or while presenting the rating button or
+                card.
+              </Text>
+            </View>
+          </View>
+        </View>
+      );
+    },
   },
   <% } %>
   <% if (props.stylingPackage?.options.selectedComponents.includes('activity-view')) { %>
   {
     name: 'Activity View',
-    component: () => (
-      <View className='items-center'>
-        <DefaultButton
-          onPress={async () => {
-            try {
-              const result = await Share.share({
-                message: 'NativeWindUI | Familiar interface, native feel.',
-              });
-              if (result.action === Share.sharedAction) {
-                if (result.activityType) {
-                  // shared with activity type of result.activityType
-                } else {
-                  // shared
+    component: function ActivityViewExample() {
+      return (
+        <View className='items-center'>
+          <DefaultButton
+            onPress={async () => {
+              try {
+                const result = await Share.share({
+                  message: 'NativeWindUI | Familiar interface, native feel.',
+                });
+                if (result.action === Share.sharedAction) {
+                  if (result.activityType) {
+                    // shared with activity type of result.activityType
+                  } else {
+                    // shared
+                  }
+                } else if (result.action === Share.dismissedAction) {
+                  // dismissed
                 }
-              } else if (result.action === Share.dismissedAction) {
-                // dismissed
+              } catch (error: any) {
+                Alert.alert(error.message);
               }
-            } catch (error: any) {
-              Alert.alert(error.message);
-            }
-          }}
-          title='Share a message'
-        />
-      </View>
-    ),
+            }}
+            title='Share a message'
+          />
+        </View>
+      );
+    },
   },
   <% } %>
   <% if (props.stylingPackage?.options.selectedComponents.includes('bottom-sheet')) { %>
   {
     name: 'Bottom Sheet',
-    component: () => {
+    component: function BottomSheetExample() {
       const { colorScheme } = useColorScheme();
       const bottomSheetModalRef = useSheetRef();
 
@@ -633,7 +663,7 @@ const COMPONENTS: ComponentItem[] = [
   <% if (props.stylingPackage?.options.selectedComponents.includes('avatar')) { %>
   {
     name: 'Avatar',
-    component: () => {
+    component: function AvatarExample() {
       const GITHUB_AVATAR_URI = 'https://github.com/mrzachnugent.png';
       return (
         <View className='items-center'>

--- a/cli/src/templates/packages/nativewindui/app/modal.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/app/modal.tsx.ejs
@@ -1,31 +1,32 @@
-import { Text } from '~/components/nativewind-ui/Text';
-import { Link } from 'expo-router';
+import { Icon } from '@roninoss/icons';
 import { StatusBar } from 'expo-status-bar';
-import { useColorScheme } from 'nativewind';
-import { Platform, View } from 'react-native';
+import { Linking, Platform, View } from 'react-native';
+
+import { Text } from '~/components/nativewind-ui/Text';
+import { useColorScheme } from '~/lib/useColorScheme';
 
 export default function ModalScreen() {
-  const { colorScheme } = useColorScheme();
+  const { colors, colorScheme } = useColorScheme();
   return (
     <>
       <StatusBar
-        style={
-          Platform.OS === 'ios'
-            ? 'light'
-            : colorScheme === 'dark'
-            ? 'light'
-            : 'dark'
-        }
+        style={Platform.OS === 'ios' ? 'light' : colorScheme === 'dark' ? 'light' : 'dark'}
       />
-      <View className='flex-1 justify-center items-center gap-8 pb-12'>
-        <View className='items-center gap-2'>
-          <Text variant='largeTitle' className='font-bold'>
+      <View className="flex-1 items-center justify-center gap-1 px-12">
+        <Icon name="file-plus-outline" size={42} color={colors.grey} />
+        <Text variant="title3" className="pb-1 text-center font-semibold">
+          NativeWindUI
+        </Text>
+        <Text color="tertiary" variant="subhead" className="pb-4 text-center">
+          You can install any of the free components from the{' '}
+          <Text
+            onPress={() => Linking.openURL('https://nativewindui.com')}
+            variant="subhead"
+            className="text-primary">
             NativeWindUI
           </Text>
-          <Link href={'https://nativewindui.com/'}>
-            <Text className='text-primary'>https://nativewindui.com/</Text>
-          </Link>
-        </View>
+          {' website.'}
+        </Text>
       </View>
     </>
   );

--- a/cli/src/templates/packages/nativewindui/components/nativewind-ui/ActivityIndicator.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/components/nativewind-ui/ActivityIndicator.tsx.ejs
@@ -6,5 +6,5 @@ export function ActivityIndicator(
   props: React.ComponentPropsWithoutRef<typeof RNActivityIndicator>
 ) {
   const { colors } = useColorScheme();
-  return <RNActivityIndicator color={colors.blue} {...props} />;
+  return <RNActivityIndicator color={colors.primary} {...props} />;
 }

--- a/cli/src/templates/packages/nativewindui/components/nativewind-ui/DatePicker.android.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/components/nativewind-ui/DatePicker.android.tsx.ejs
@@ -4,7 +4,7 @@ import DateTimePicker, {
 import * as React from 'react';
 import { Pressable, View } from 'react-native';
 
-import { Text } from '~/components/Text';
+import { Text } from '~/components/nativewind-ui/Text';
 
 export function DatePicker(
   props: React.ComponentProps<typeof DateTimePicker> & {

--- a/cli/src/templates/packages/nativewindui/components/nativewind-ui/Slider.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/components/nativewind-ui/Slider.tsx.ejs
@@ -14,12 +14,12 @@ export function Slider({
   return (
     <RNSlider
       thumbTintColor={
-        thumbTintColor ?? Platform.OS === 'ios' ? COLORS.white : colors.blue
+        thumbTintColor ?? Platform.OS === 'ios' ? COLORS.white : colors.primary
       }
-      minimumTrackTintColor={minimumTrackTintColor ?? colors.blue}
+      minimumTrackTintColor={minimumTrackTintColor ?? colors.primary}
       maximumTrackTintColor={
         maximumTrackTintColor ?? Platform.OS === 'android'
-          ? colors.blue
+          ? colors.primary
           : undefined
       }
       {...props}

--- a/cli/src/templates/packages/nativewindui/components/nativewind-ui/Text.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/components/nativewind-ui/Text.tsx.ejs
@@ -1,18 +1,16 @@
 import { VariantProps, cva } from 'class-variance-authority';
-import { cssInterop } from 'nativewind';
 import * as React from 'react';
-<% if (props.stylingPackage?.options.selectedComponents.includes('actionable-text')) { %>
+<% if (props.stylingPackage?.options.selectedComponents.includes('selectable-text')) { %>
 import { UITextView } from 'react-native-uitextview';
+import { cssInterop } from 'nativewind';
 <% } else { %>
 import { Text as RNText } from 'react-native';
 <% } %>
 
 import { cn } from '~/lib/cn';
 
-<% if (props.stylingPackage?.options.selectedComponents.includes('actionable-text')) { %>
+<% if (props.stylingPackage?.options.selectedComponents.includes('selectable-text')) { %>
 cssInterop(UITextView, { className: 'style' });
-<% } else { %>
-cssInterop(RNText, { className: 'style' });
 <% } %>
 
 const textVariants = cva('text-foreground', {
@@ -45,7 +43,7 @@ const textVariants = cva('text-foreground', {
 
 const TextClassContext = React.createContext<string | undefined>(undefined);
 
-<% if (props.stylingPackage?.options.selectedComponents.includes('actionable-text')) { %>
+<% if (props.stylingPackage?.options.selectedComponents.includes('selectable-text')) { %>
 function Text({
   className,
   variant,

--- a/cli/src/templates/packages/nativewindui/components/nativewind-ui/ThemeToggle.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/components/nativewind-ui/ThemeToggle.tsx.ejs
@@ -1,5 +1,5 @@
 import { Icon } from '@roninoss/icons';
-import { Appearance, Pressable, View } from 'react-native';
+import { Pressable, View } from 'react-native';
 import Animated, { LayoutAnimationConfig, ZoomInRotate } from 'react-native-reanimated';
 
 import { cn } from '~/lib/cn';
@@ -7,7 +7,7 @@ import { useColorScheme } from '~/lib/useColorScheme';
 import { COLORS } from '~/theme/colors';
 
 export function ThemeToggle() {
-  const { colorScheme, toggleColorScheme } = useColorScheme();
+  const { colorScheme, setColorScheme } = useColorScheme();
   return (
     <LayoutAnimationConfig skipEntering>
       <Animated.View
@@ -16,9 +16,7 @@ export function ThemeToggle() {
         entering={ZoomInRotate}>
         <Pressable
           onPress={() => {
-            // ColorScheme is set with `Appearance` as well for the iOS header search placeholder text: https://github.com/software-mansion/react-native-screens/discussions/1758
-            Appearance.setColorScheme(colorScheme === 'dark' ? 'light' : 'dark');
-            toggleColorScheme();
+            setColorScheme(colorScheme === 'dark' ? 'light' : 'dark');
           }}
           className="opacity-80">
           {colorScheme === 'dark'

--- a/cli/src/templates/packages/nativewindui/components/nativewind-ui/Toggle.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/components/nativewind-ui/Toggle.tsx.ejs
@@ -7,7 +7,7 @@ export function Toggle(props: React.ComponentPropsWithoutRef<typeof Switch>) {
   return (
     <Switch
       trackColor={{
-        true: colors.blue,
+        true: colors.primary,
         false: colors.grey,
       }}
       thumbColor={COLORS.white}

--- a/cli/src/templates/packages/nativewindui/global.css.ejs
+++ b/cli/src/templates/packages/nativewindui/global.css.ejs
@@ -38,7 +38,7 @@
     --android-muted-foreground: 113 119 134;
     --android-accent: 169 73 204;
     --android-accent-foreground: 255 255 255;
-    --android-destructive: 254 67 54;
+    --android-destructive: 186 26 26;
     --android-destructive-foreground: 255 255 255;
     --android-border: 215 217 228;
     --android-input: 210 210 215;

--- a/cli/src/templates/packages/nativewindui/lib/useHeaderSearchBar.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/lib/useHeaderSearchBar.tsx.ejs
@@ -18,7 +18,7 @@ export function useHeaderSearchBar(props: SearchBarProps = {}) {
         tintColor: colors.primary,
         headerIconColor: colors.foreground,
         hintTextColor: colors.grey,
-        hideWhenScrolling: true,
+        hideWhenScrolling: false,
         onChangeText(ev) {
           setSearch(ev.nativeEvent.text);
         },

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -41,7 +41,7 @@ export type Internalization = 'i18next';
 
 export type SelectedComponents =
   | 'action-sheet'
-  | 'actionable-text'
+  | 'selectable-text'
   | 'activity-indicator'
   | 'activity-view'
   | 'alert'

--- a/cli/src/utilities/runCLI.ts
+++ b/cli/src/utilities/runCLI.ts
@@ -121,7 +121,6 @@ export async function runCLI(toolbox: Toolbox, projectName: string): Promise<Cli
       message: 'Which components would you like to explore?',
       options: [
         { value: 'action-sheet', label: 'Action Sheet' },
-        { value: 'actionable-text', label: 'Actionable Text' },
         { value: 'activity-indicator', label: 'Activity Indicator' },
         { value: 'activity-view', label: 'Activity View' },
         { value: 'alert', label: 'Alert' },
@@ -134,6 +133,7 @@ export async function runCLI(toolbox: Toolbox, projectName: string): Promise<Cli
         { value: 'progress-indicator', label: 'Progress Indicator' },
         { value: 'ratings-indicator', label: 'Ratings Indicator' },
         { value: 'segmented-control', label: 'Segmented Control' },
+        { value: 'selectable-text', label: 'Selectable Text' },
         { value: 'slider', label: 'Slider' },
         { value: 'text', label: 'Text' },
         { value: 'toggle', label: 'Toggle' }
@@ -141,7 +141,7 @@ export async function runCLI(toolbox: Toolbox, projectName: string): Promise<Cli
       required: false,
       initialValues: [
         'action-sheet',
-        'actionable-text',
+        'selectable-text',
         'activity-indicator',
         'activity-view',
         'alert',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Your title should include which part of the project your PR applies to (ex: [cli], [docs], [www]) -->

## Description

<!--- Describe your changes in detail -->
<!--- If your PR affects visual changes then please provide before and after images, gifs, or videos (below) -->

- Fix wrong matching of color schemes by setting the userInterfaceStyle to automatic and changing color scheme with `setColorScheme` instead of `toggleColorScheme`. This led to issues like the wrong search bar color in the header.
- Change "actionnable-text" for "selectable-text"
- Only include `GestureHandlerRootView` with "bottom-sheet"
- Remove top-tab-navigation options
- Make settings page content similar to empty list content with non components selected
- Adjust empty list component to work for both ios and android in and do it in the same way.
- Fix color key "regression" ie: blue and red are now primary and destructive
- Fix android date picker import
- Only use `cssInterop` with uiTextView as it is not necessary for react-native's text component
- Fix an android css variable
- Hide header scrollbar on initial render when no components were selected
- Fix typescript erros for components list
- For the store review, removed the button and prompt the user when component is lazy loaded and show main guidelines.

## Related Issue

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue linked above, you can remove this section -->

## How Has This Been Tested?

Locally with bun. Only tested all components selected and only selectable-text unselected.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Store review main guidelines: (the trailing slash after "button" was removed after image was taken)
<img width="345" alt="Screenshot 2024-04-18 at 1 46 06 PM" src="https://github.com/danstepanov/create-expo-stack/assets/63797719/50061914-4eb4-4be6-a80d-f9633c21c6a6">

Settings screen:
<img width="354" alt="Screenshot 2024-04-18 at 1 45 36 PM" src="https://github.com/danstepanov/create-expo-stack/assets/63797719/bbe00703-b886-4c12-9eeb-bf1b37797817">

No components selected: Empty List with hidden search bar:
<img width="354" alt="Screenshot 2024-04-18 at 1 44 15 PM" src="https://github.com/danstepanov/create-expo-stack/assets/63797719/7ff5bb71-bc07-433e-abbb-64a8f2367058">


