### PR TITLE
[cli] nw-ui/store-review handle error and show once + steady progress amount

### DIFF
--- a/cli/src/templates/packages/nativewindui/app/index.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/app/index.tsx.ejs
@@ -172,7 +172,9 @@ function Card({ children, title }: { children: React.ReactNode; title: string })
     </View>
   );
 }
-
+<% if (props.stylingPackage?.options.selectedComponents.includes('ratings-indicator')) { %>
+let hasRequestedReview = false;
+<% } %>
 const COMPONENTS: ComponentItem[] = [
   <% if (props.stylingPackage?.options.selectedComponents.includes('picker')) { %>
   {
@@ -375,7 +377,7 @@ const COMPONENTS: ComponentItem[] = [
         if (!id) {
           id = setInterval(() => {
             setProgress((prev) => (prev >= 99 ? 0 : prev + 5));
-          }, Math.random() * 3000);
+          }, 1000);
         }
         return () => {
           if (id) clearInterval(id);
@@ -569,9 +571,18 @@ const COMPONENTS: ComponentItem[] = [
     component: function RatingsIndicatorExample() {
       React.useEffect(() => {
         async function showRequestReview() {
-          if (await StoreReview.hasAction()) {
-            // For android, make sure you meet all conditions to be able to test and use it: https://developer.android.com/guide/playcore/in-app-review/test#troubleshooting
-            StoreReview.requestReview();
+          if (hasRequestedReview) return;
+          try {
+            if (await StoreReview.hasAction()) {
+              await StoreReview.requestReview();
+            }
+          } catch (error) {
+            console.log(
+              'FOR ANDROID: Make sure you meet all conditions to be able to test and use it: https://developer.android.com/guide/playcore/in-app-review/test#troubleshooting',
+              error
+            );
+          } finally {
+            hasRequestedReview = true;
           }
         }
         const timeout = setTimeout(() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Your title should include which part of the project your PR applies to (ex: [cli], [docs], [www]) -->

## Description
- Handle gracefully store review promise
  - Show in console error 
  -  show link to android conditions (for example, app needs to be at least in internal testing in play store to work)
 - Prevent store review prompt from showing on every lazy load (scrolling far away then scrolling back to it). 
 - Set the progress indicator to increase every second to prevent really fast progress increase randomly.