### PR TITLE
fix paddings and font sizes in multiple places to make it look nicer

### DIFF
--- a/www/src/components/landing/roadmap/roadmap.tsx
+++ b/www/src/components/landing/roadmap/roadmap.tsx
@@ -54,15 +54,15 @@ export default function Roadmap() {
     >
       <div className="flex w-full max-w-3xl flex-col items-center px-4 sm:px-8">
         <div className="glow relative flex w-full flex-col items-center"></div>
-        <h1 className="bg-gradient-to-r from-slate-50 via-yellow-500 to-orange-500 bg-clip-text pb-6 text-center font-bold text-transparent text-3xl md:text-4xl">
+        <h1 className="bg-gradient-to-r from-neutral-50 via-yellow-500 to-orange-500 bg-clip-text pb-6 text-center font-bold text-transparent text-3xl md:text-4xl">
           What&apos;s next for Create Expo Stack?
         </h1>
-        <p className="w-full pb-12 px-16 text-sm sm:text-base md:text-lg text-center leading-relaxed text-transparent bg-gradient-to-r from-slate-400/70 via-slate-300/70 to-pink-200/70 bg-clip-text">
+        <p className="w-full pb-12 px-8 md:px-16 md:text-lg text-center leading-loose text-transparent font-thin bg-gradient-to-r from-neutral-400/70 via-neutral-300/70 to-orange-200/70 bg-clip-text">
           This is a list of features we&apos;re working on, and what we intend
           to release in future versions. This list is subject to change and will
           be updated as we make progress.
         </p>
-        <section className="grid pb-20 sm:-ml-[6.5rem] text-slate-200">
+        <section className="grid pb-10 sm:pb-20 sm:-ml-[6.5rem] text-neutral-200">
           {roadmapData.map((item, index) => (
             <div key={index} className="flex gap-6">
               <div className="flex w-full max-w-[80px] translate-y-4 items-start justify-end gap-6">
@@ -85,9 +85,15 @@ export default function Roadmap() {
                   )}
                 </div>
               </div>
-              <div className="mb-2 flex w-full flex-col gap-2 rounded-lg bg-white/5 backdrop-saturate-150 px-4 py-4 backdrop-blur-[2px]">
-                <h3 className="text-base font-bold sm:text-lg">{item.title}</h3>
-                <p className="text-sm text-slate-300/70 px-16">
+              <div
+                className={`mb-2 flex w-full flex-col gap-2 rounded-lg bg-white/5 backdrop-saturate-150 px-4 py-4 backdrop-blur-[2px] ${
+                  item.active && "rounded-t-3xl"
+                }`}
+              >
+                <h3 className="text-left sm:text-center text-base font-bold sm:text-lg">
+                  {item.title}
+                </h3>
+                <p className="text-left sm:text-center text-sm font-light text-neutral-300/70 md:px-16">
                   {item.description}
                 </p>
               </div>
@@ -96,10 +102,10 @@ export default function Roadmap() {
         </section>
         <div className="flex w-full flex-col gap-2 bg-white/5 backdrop-saturate-150 backdrop-blur-[2px] rounded-lg rounded-tl-3xl sm:rounded-tl-lg rounded-b-3xl -mt-10 sm:-mt-20 px-10 py-8 relative overflow-hidden">
           <h3 className="text-2xl font-bold">That&apos;s not all!</h3>
-          <p className="text-slate-300/70">
+          <p className="text-neutral-300/70">
             We&apos;re always open to new ideas and feedback over{" "}
             <a
-              className="font-bold bg-indigo-200/30 px-2 py-0.5 rounded-3xl text-white hover:text-indigo-300 hover:decoration-wavy underline hover:decoration-indigo-300 duration-300 hover:py-3"
+              className="font-bold bg-orange-200/30 px-2 py-0.5 rounded-3xl text-white hover:text-orange-300 hover:decoration-wavy underline hover:decoration-orange-300 duration-300 hover:py-3"
               href="https://rn.new/discord"
               target="_blank"
               rel="noopener noreferrer"

--- a/www/src/components/landing/terminal/terminal.astro
+++ b/www/src/components/landing/terminal/terminal.astro
@@ -4,7 +4,7 @@ import Filetree from "../filetree.astro";
 
 <div
   id="cli-container"
-  class="relative w-[90%] lg:w-[69%] 2xl:w-[60%] h-[55vh] lg:h-[45.5rem] p-4 sm:p-5 lg:p-6 text-white/70 flex-col z-[1] rounded-2xl sm:rounded-3xl xl:rounded-[2rem] bg-white/10 overflow-wrap overflow-hidden backdrop-blur-sm opacity-75 md:flex hidden"
+  class="relative w-[90%] lg:w-[69%] 2xl:w-[60%] h-[55vh] lg:h-[44.75rem] pl-4 sm:pl-5 lg:pl-6 text-white/70 flex-col z-[1] rounded-2xl sm:rounded-3xl xl:rounded-[2rem] bg-white/10 overflow-wrap overflow-hidden backdrop-blur-sm opacity-75 md:flex hidden"
 >
   <pre id="terminal"></pre>
 </div>

--- a/www/src/components/landing/testimonials/testimonials.tsx
+++ b/www/src/components/landing/testimonials/testimonials.tsx
@@ -64,7 +64,7 @@ export default function Testimonials() {
 
   return (
     <section className="z-10 w-[90%] lg:w-[70%] sm:w-auto">
-      <h1 className="text-center text-4xl font-bold tracking-tight text-white md:text-6xl lg:text-[4rem] xl:text-[4rem] pb-16 pt-24 2xl:pt-0">
+      <h1 className="text-center text-4xl font-bold tracking-tight text-white md:text-6xl lg:text-[4rem] xl:text-[4rem] pb-16 pt-24 2xl:pt-12">
         What people are saying
       </h1>
       <div className="infinite-scroll-x-container mx-auto max-w-7xl px-6 sm:px-8">

--- a/www/src/styles/globals.css
+++ b/www/src/styles/globals.css
@@ -135,7 +135,7 @@ html {
 #cli-demo::before {
   inset: 0;
   content: "";
-  --angle: 128deg;
+  --angle: 150deg;
   position: absolute;
   border-radius: inherit;
   padding: 1.5px;
@@ -154,7 +154,7 @@ html {
   -webkit-mask:
     linear-gradient(#fff 0 0) content-box,
     linear-gradient(#fff 0 0);
-  animation: 10s rotate ease-in-out infinite;
+  /* animation: 10s rotate ease-in-out infinite; */
   mask-composite: exclude;
   pointer-events: none;
 }
@@ -196,7 +196,7 @@ html {
   -webkit-mask:
     linear-gradient(#fff 0 0) content-box,
     linear-gradient(#fff 0 0);
-  animation: 10s rotate ease-in-out infinite;
+  /* animation: 10s rotate ease-in-out infinite; */
   mask-composite: exclude;
   pointer-events: none;
 }


### PR DESCRIPTION
- shiny animation was disabled as it consumed too much resources and slowed down other transitions on mobile
<img width="126" alt="Screenshot 2024-05-15 at 6 07 40 PM" src="https://github.com/danstepanov/create-expo-stack/assets/31113245/db98ad9d-9cce-4bf8-9282-60e96f66138b">

no padding on the terminal as you scroll to make it feel more real
<img width="1125" alt="Screenshot 2024-05-15 at 6 06 13 PM" src="https://github.com/danstepanov/create-expo-stack/assets/31113245/17e4acc5-ea11-415f-92c9-da1707a3a7af">
before (with padding) gaps on the top & bottom and border radius cut-off
<img width="1128" alt="Screenshot 2024-05-15 at 6 07 11 PM" src="https://github.com/danstepanov/create-expo-stack/assets/31113245/689b05ac-3433-451c-8856-80403c54860e">


testimonials gap 2xl: before
<img width="1728" alt="Screenshot 2024-05-15 at 6 01 41 PM" src="https://github.com/danstepanov/create-expo-stack/assets/31113245/51eeb723-b84d-4393-8439-be1b05388f46">
testimonials gap 2xl after
<img width="1728" alt="Screenshot 2024-05-15 at 6 01 57 PM" src="https://github.com/danstepanov/create-expo-stack/assets/31113245/eec5a6be-6fd1-4bbe-8089-f3074eb40899">


roadmap before 
<img width="500" align=left alt="Screenshot 2024-05-15 at 5 59 53 PM" src="https://github.com/danstepanov/create-expo-stack/assets/31113245/405de936-2426-416d-b87b-7c20e1d9beff">
<img width="150" align=left alt="Screenshot 2024-05-15 at 6 00 18 PM" src="https://github.com/danstepanov/create-expo-stack/assets/31113245/4b22e052-c7fc-4303-84bc-28b6786f0770">

\
\
\
roadmap after
<img width="500" align=left alt="Screenshot 2024-05-15 at 6 00 48 PM" src="https://github.com/danstepanov/create-expo-stack/assets/31113245/25886f5b-b1b9-4dc9-b6a1-f4e3d8a1ab72">
<img width="150" align=left alt="Screenshot 2024-05-15 at 6 01 06 PM" src="https://github.com/danstepanov/create-expo-stack/assets/31113245/04784a76-64f2-4cee-a8ae-8455f3402469">
