### PR TITLE
[cli] update dark android navigation bar color to match light mode

### DIFF
--- a/.changeset/tiny-gorillas-add.md
+++ b/.changeset/tiny-gorillas-add.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+Makes the dark mode android navigation bar more transparent for NativeWindUI

--- a/cli/src/templates/packages/nativewindui/lib/useColorScheme.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/lib/useColorScheme.tsx.ejs
@@ -50,6 +50,6 @@ function setNavigationBar(colorScheme: 'light' | 'dark') {
   return Promise.all([
     NavigationBar.setButtonStyleAsync(colorScheme === 'dark' ? 'light' : 'dark'),
     NavigationBar.setPositionAsync('absolute'),
-    NavigationBar.setBackgroundColorAsync(colorScheme === 'dark' ? '#00000080' : '#ffffff80'),
+    NavigationBar.setBackgroundColorAsync(colorScheme === 'dark' ? '#00000030' : '#ffffff80'),
   ]);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Your title should include which part of the project your PR applies to (ex: [cli], [docs], [www]) -->

## Description

Makes the dark mode android navigation bar more transparent for NativeWindUI

## Motivation and Context

The android navigation bar was more noticeable in dark mode than in light mode.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue linked above, you can remove this section -->

