### PR TITLE
feat: exit on no install eas

### DIFF
--- a/.changeset/plenty-toys-pull.md
+++ b/.changeset/plenty-toys-pull.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+exits when eas and no install are chosen together since its not possible

--- a/cli/src/utilities/printOutput.ts
+++ b/cli/src/utilities/printOutput.ts
@@ -5,40 +5,7 @@ import { AvailablePackages, CliResults } from '../types';
 import { copyBaseAssets } from './copyBaseAssets';
 import { outro, spinner } from '@clack/prompts';
 import { easConfigure } from './runEasConfigure';
-
-type STDIO = 'inherit' | 'ignore' | 'pipe' | 'overlapped';
-
-const onlyErrors = ['ignore', 'ignore', 'inherit'] as const;
-
-async function runSystemCommand({
-  command,
-  errorMessage,
-  stdio,
-  toolbox
-}: {
-  command: string;
-  toolbox: Toolbox;
-  stdio: readonly [STDIO, STDIO, STDIO] | STDIO | undefined;
-  errorMessage: string;
-}) {
-  const {
-    print: { error },
-    system
-  } = toolbox;
-
-  const result = await system.spawn(command, {
-    shell: true,
-    stdio
-  });
-
-  if (result.error || result.status !== 0) {
-    error(`${errorMessage}: ${JSON.stringify(result)}`);
-
-    error(`failed to run command: ${command}`);
-
-    return process.exit(1);
-  }
-}
+import { ONLY_ERRORS, runSystemCommand } from './systemCommand';
 
 export async function printOutput(
   cliResults: CliResults,
@@ -78,7 +45,7 @@ export async function printOutput(
     await runSystemCommand({
       toolbox,
       command: `cd ${projectName} && ${packageManager} install --silent`,
-      stdio: packageManager === 'npm' ? undefined : onlyErrors,
+      stdio: packageManager === 'npm' ? undefined : ONLY_ERRORS,
       errorMessage: 'Error installing dependencies'
     });
 
@@ -91,7 +58,7 @@ export async function printOutput(
     await runSystemCommand({
       toolbox,
       command: `cd ${projectName} && ${packageManager} ${installCommand} --silent expo@latest`,
-      stdio: isNpm ? undefined : onlyErrors,
+      stdio: isNpm ? undefined : ONLY_ERRORS,
       errorMessage: 'Error updating expo'
     });
 
@@ -129,7 +96,7 @@ export async function printOutput(
       toolbox,
       command: `${runnerType} prettier "${projectName}/**/*.{json,js,jsx,ts,tsx}" --no-config --write`,
       errorMessage: 'Error formatting code',
-      stdio: onlyErrors
+      stdio: ONLY_ERRORS
     });
 
     s.stop('Project files formatted!');

--- a/cli/src/utilities/systemCommand.ts
+++ b/cli/src/utilities/systemCommand.ts
@@ -1,0 +1,35 @@
+import { Toolbox } from 'gluegun/build/types/domain/toolbox';
+
+type STDIO = 'inherit' | 'ignore' | 'pipe' | 'overlapped';
+
+export const ONLY_ERRORS = ['ignore', 'ignore', 'inherit'] as const;
+
+export async function runSystemCommand({
+  command,
+  errorMessage,
+  stdio,
+  toolbox
+}: {
+  command: string;
+  toolbox: Toolbox;
+  stdio: readonly [STDIO, STDIO, STDIO] | STDIO | undefined;
+  errorMessage: string;
+}) {
+  const {
+    print: { error },
+    system
+  } = toolbox;
+
+  const result = await system.spawn(command, {
+    shell: true,
+    stdio
+  });
+
+  if (result.error || result.status !== 0) {
+    error(`${errorMessage}: ${JSON.stringify(result)}`);
+
+    error(`failed to run command: ${command}`);
+
+    return process.exit(1);
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Your title should include which part of the project your PR applies to (ex: [cli], [docs], [www]) -->

## Description

If you try to run eas configure without running install it fails to find config plugins that its looking for, not to mention that running prebuild requires the packages to be installed.

<!--- Describe your changes in detail -->
<!--- If your PR affects visual changes then please provide before and after images, gifs, or videos (below) -->

## Related Issue

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue linked above, you can remove this section -->

Its a bad experience if we just let it fail with a cryptic message.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran locally.

## Screenshots (if appropriate):
