### PR TITLE
fix: correctly fallback to npm

### DIFF
--- a/.changeset/tricky-students-sniff.md
+++ b/.changeset/tricky-students-sniff.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+fix: issues falling back to npm

--- a/cli/src/utilities/getPackageManager.ts
+++ b/cli/src/utilities/getPackageManager.ts
@@ -9,12 +9,13 @@ export function getPackageManager(toolbox: Toolbox, cliResults: CliResults): Pac
   const {
     parameters: { options }
   } = toolbox;
+
   if (options.npm) return 'npm';
   if (options.yarn) return 'yarn';
   if (options.pnpm) return 'pnpm';
   if (options.bun) return 'bun';
 
-  if (cliResults.flags.packageManager !== 'npm') {
+  if (cliResults.flags.packageManager && cliResults.flags.packageManager !== 'npm') {
     return cliResults.flags.packageManager;
   }
 
@@ -31,9 +32,11 @@ export function getPackageManager(toolbox: Toolbox, cliResults: CliResults): Pac
     } else {
       return 'npm';
     }
-  } else {
+  } else if (cliResults.flags.packageManager) {
     // If no user agent is set, assume npm
     return cliResults.flags.packageManager;
+  } else {
+    return 'npm';
   }
 }
 export function getPackageManagerRunnerX(toolbox: Toolbox, cliResults: CliResults): PackageManagerRunnerX {

--- a/cli/src/utilities/runCLI.ts
+++ b/cli/src/utilities/runCLI.ts
@@ -107,12 +107,15 @@ export async function runCLI(toolbox: Toolbox, projectName: string): Promise<Cli
         return process.exit(0);
       }
       if (!shouldUseDefaultPackageManager) {
-        const packageManagers: PackageManager[] = ['npm', 'yarn', 'pnpm', 'bun'];
-
         const packageManagerSelect = await select({
           message: 'Gotcha! Which package manager would you like to use?',
-          options: packageManagers.map((manager) => ({ value: manager, label: manager })),
-          initialValue: packageManagers[0]
+          options: [
+            { value: 'npm', label: 'npm' },
+            { value: 'yarn', label: 'yarn' },
+            { value: 'pnpm', label: 'pnpm' },
+            { value: 'bun', label: 'bun' }
+          ] satisfies Array<{ value: PackageManager; label: string }>,
+          initialValue: 'npm' as PackageManager
         });
 
         if (isCancel(packageManagerSelect)) {

--- a/cli/src/utilities/runCLI.ts
+++ b/cli/src/utilities/runCLI.ts
@@ -107,14 +107,12 @@ export async function runCLI(toolbox: Toolbox, projectName: string): Promise<Cli
         return process.exit(0);
       }
       if (!shouldUseDefaultPackageManager) {
+        const packageManagers: PackageManager[] = ['npm', 'yarn', 'pnpm', 'bun'];
+
         const packageManagerSelect = await select({
           message: 'Gotcha! Which package manager would you like to use?',
-          options: [
-            { value: 'npm', label: 'npm' },
-            { value: 'yarn', label: 'yarn' },
-            { value: 'pnpm', label: 'pnpm' },
-            { value: 'bun', label: 'bun' }
-          ]
+          options: packageManagers.map((manager) => ({ value: manager, label: manager })),
+          initialValue: packageManagers[0]
         });
 
         if (isCancel(packageManagerSelect)) {
@@ -122,7 +120,7 @@ export async function runCLI(toolbox: Toolbox, projectName: string): Promise<Cli
           return process.exit(0);
         }
 
-        cliResults.flags.packageManager = packageManagerSelect as PackageManager;
+        cliResults.flags.packageManager = packageManagerSelect;
       }
     }
   } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Your title should include which part of the project your PR applies to (ex: [cli], [docs], [www]) -->

## Description

At times the package manger wouldn't resolve correctly because neither the user agent or cli flag is set.

The issue was that the flag value was coming back undefined, I just double checked this and made the fallback more explicit.

<!--- Describe your changes in detail -->
<!--- If your PR affects visual changes then please provide before and after images, gifs, or videos (below) -->

## Related Issue

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

We should always fallback to a valid option is not provided

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue linked above, you can remove this section -->

## How Has This Been Tested?

yes locally

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
