### PR TITLE
[cli] Fix nativewind import when not required

### DIFF
--- a/.changeset/gold-ads-shake.md
+++ b/.changeset/gold-ads-shake.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+Fix unneceserry import of nativewind when not required

--- a/cli/src/templates/packages/expo-router/metro.config.js.ejs
+++ b/cli/src/templates/packages/expo-router/metro.config.js.ejs
@@ -1,6 +1,6 @@
 // Learn more https://docs.expo.io/guides/customizing-metro
 const { getDefaultConfig } = require('expo/metro-config');
-<% if (props.stylingPackage?.name === "nativewind" || "nativewindui") { %>
+<% if (["nativewind", "nativewindui"].includes(props.stylingPackage?.name)) { %>
   const { withNativeWind } = require("nativewind/metro");
 <% } %>
 

--- a/cli/src/templates/packages/nativewindui/drawer/app/+not-found.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/drawer/app/+not-found.tsx.ejs
@@ -1,5 +1,5 @@
 import { Link, Stack } from 'expo-router';
-<% if (props.stylingPackage?.name === "nativewind" || "nativewindui") {%>
+<% if (["nativewind", "nativewindui"].includes(props.stylingPackage?.name)) {%>
   import { Text } from 'react-native';
 
   import { Container } from '~/components/Container';
@@ -29,7 +29,7 @@ export default function NotFoundScreen() {
 <% } %>
 
   return (
-      <% if (props.stylingPackage?.name === "nativewind" || "nativewindui") {%>
+      <% if (["nativewind", "nativewindui"].includes(props.stylingPackage?.name)) {%>
         <>
           <Stack.Screen options={{ title: "Oops!" }} />
           <Container>
@@ -77,7 +77,7 @@ export default function NotFoundScreen() {
   );
 }
 
-<% if (props.stylingPackage?.name === "nativewind" || "nativewindui") { %>
+<% if (["nativewind", "nativewindui"].includes(props.stylingPackage?.name)) { %>
   const styles = {
     title: `text-xl font-bold`,
     link: `mt-4 pt-4`,

--- a/cli/src/templates/packages/nativewindui/tabs/app/+not-found.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/tabs/app/+not-found.tsx.ejs
@@ -1,5 +1,5 @@
 import { Link, Stack } from 'expo-router';
-<% if (props.stylingPackage?.name === "nativewind" || "natiwindui") {%>
+<% if (["nativewind", "nativewindui"].includes(props.stylingPackage?.name)) {%>
   import { Text, View } from 'react-native';
 <% } else if (props.stylingPackage?.name === "unistyles") { %>
   import { createStyleSheet, useStyles } from 'react-native-unistyles'
@@ -23,7 +23,7 @@ export default function NotFoundScreen() {
 <% } %>
 
   return (
-      <% if (props.stylingPackage?.name === "nativewind" || "nativewindui") {%>
+      <% if (["nativewind", "nativewindui"].includes(props.stylingPackage?.name)) {%>
         <>
           <Stack.Screen options={{ title: "Oops!" }} />
           <View className={styles.container}>
@@ -71,7 +71,7 @@ export default function NotFoundScreen() {
   );
 }
 
-<% if (props.stylingPackage?.name === "nativewind" || "nativewindui") { %>
+<% if (["nativewind", "nativewindui"].includes(props.stylingPackage?.name)) { %>
   const styles = {
 		container: `items-center flex-1 justify-center p-5`,
     title: `text-xl font-bold`,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Your title should include which part of the project your PR applies to (ex: [cli], [docs], [www]) -->

## Description

Some `nativewind` code was added when it was not required. The bug was coming from a mistake in the if statement. :
```
<% if (props.stylingPackage?.name === "nativewind" || "nativewindui") { %>
```
In the following case, the if will always be "true" because `|| "nativewindui"` will always evaluate to true:

The fixed if statement is:
```
<% if (["nativewind", "nativewindui"].includes(props.stylingPackage?.name)) { %>
```

## Related Issue

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/danstepanov/create-expo-stack/issues/318

## How Has This Been Tested?
- Created a new project with Expo router and without any nativewind, and it was fixed - the inport was not there, and the app runs correctly
- Created a new project with NativeWindUI and the imports where added correctly
