### PR TITLE
[www] update website CLI to instruct to expo prebuild for NativeWindUI

### DIFF
--- a/www/demo/steps/printOutput.js
+++ b/www/demo/steps/printOutput.js
@@ -12,25 +12,37 @@ function generateStepsToRunProject(cliResults) {
   let output = color.blue(`${step}. cd ${cliResults.projectName}\n`);
   if (cliResults.flags.packageManager === "npm") {
     output += color.blue(`${++step}. npm install\n`);
-    if (stylingPackage.name === "unistyles") {
+    if (
+      stylingPackage.name === "unistyles" ||
+      stylingPackage.name === "nativewindui"
+    ) {
       output += color.blue(`${++step}. npx expo prebuild --clean\n`);
     }
     output += color.blue(`${++step}. npm run ios`);
   } else if (cliResults.flags.packageManager === "pnpm") {
     output += color.blue(`${++step}. pnpm install\n`);
-    if (stylingPackage.name === "unistyles") {
+    if (
+      stylingPackage.name === "unistyles" ||
+      stylingPackage.name === "nativewindui"
+    ) {
       output += color.blue(`${++step}. pnpm expo prebuild --clean\n`);
     }
     output += color.blue(`${++step}. pnpm run ios`);
   } else if (cliResults.flags.packageManager === "bun") {
     output += color.blue(`${++step}. bun install\n`);
-    if (stylingPackage.name === "unistyles") {
+    if (
+      stylingPackage.name === "unistyles" ||
+      stylingPackage.name === "nativewindui"
+    ) {
       output += color.blue(`${++step}. bun expo prebuild --clean\n`);
     }
     output += color.blue(`${++step}. bun run ios`);
   } else {
     output += color.blue(`${++step}. yarn install\n`);
-    if (stylingPackage.name === "unistyles") {
+    if (
+      stylingPackage.name === "unistyles" ||
+      stylingPackage.name === "nativewindui"
+    ) {
       output += color.blue(`${++step}. yarn expo prebuild --clean\n`);
     }
     output += color.blue(`${++step}. yarn ios`);


### PR DESCRIPTION
## Description

The _**website's**_ interactive CLI has separate code for the prompt + project's post-generation instructions, as it calls out to an API that actually generates the requested project. This PR updates the post-generation instructions to match the actual CLI for when `nativewindui` is selected, instructing the user to run `expo prebuild`.

## Related Issue

N/A

## Motivation and Context

Users who generate NativeWind UI projects need to run `expo prebuild` before their project will work.

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):

N/A