### PR TITLE
[cli] Fix tamagui button

### DIFF
--- a/.changeset/loud-geckos-leave.md
+++ b/.changeset/loud-geckos-leave.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+Fix tamagui button

--- a/cli/src/templates/packages/tamagui/components/Button.tsx.ejs
+++ b/cli/src/templates/packages/tamagui/components/Button.tsx.ejs
@@ -1,10 +1,16 @@
-import { forwardRef } from 'react';
-import { Button as TButton, ButtonText } from '../tamagui.config';
+import { ComponentProps, forwardRef } from 'react';
+import { TamaguiElement } from 'tamagui';
 
-export const Button = forwardRef<TouchableOpacity, ButtonProps>(({ onPress, title }, ref) => {
+import { Button as TButton } from '../tamagui.config';
+
+type ButtonProps = {
+  title: string;
+} & ComponentProps<typeof TButton>;
+
+export const Button = forwardRef<TamaguiElement, ButtonProps>(({ title, ...tButtonProps }, ref) => {
   return (
-    <TButton onPress={onPress}>
-      <ButtonText>{title}</ButtonText>
+    <TButton {...tButtonProps} ref={ref}>
+      {title}
     </TButton>
   );
 });

--- a/cli/src/templates/packages/tamagui/tamagui.config.ts.ejs
+++ b/cli/src/templates/packages/tamagui/tamagui.config.ts.ejs
@@ -4,7 +4,7 @@ import { createMedia } from "@tamagui/react-native-media-driver";
 import { shorthands } from "@tamagui/shorthands";
 import { themes, tokens } from "@tamagui/themes";
 <% if (props.navigationPackage?.type === "navigation") { %>
-	import { createTamagui, styled, SizableText, H1, YStack } from "tamagui";
+	import { createTamagui, styled, SizableText, H1, YStack, Button as ButtonTamagui } from "tamagui";
 <% } else { %>
   import { createTamagui } from "tamagui";
 <% } %>
@@ -54,33 +54,32 @@ const bodyFont = createInterFont();
     color: '#38434D',
     size: '$9',
   });
-<% } %>
-<% if (props.navigationPackage?.options.type === "stack") { %>
-	export const Button = styled(YStack, {
-		alignItems: 'center',
-		backgroundColor: '#6366F1',
-		borderRadius: 28,
-    hoverStyle: {
-			backgroundColor: '#5a5fcf',
-		},
-		justifyContent: 'center',
-    maxWidth: 500,
-		padding: 16,
-		shadowColor: '#000',
-		shadowOffset: {
-			height: 2,
-			width: 0,
-		},
-		shadowOpacity: 0.25,
-		shadowRadius: 3.84,
-	});
 
-	export const ButtonText = styled(SizableText, {
-		color: '#FFFFFF',
-		fontSize: 16,
-		fontWeight: '600',
-		textAlign: 'center',
-	});
+  export const Button = styled(ButtonTamagui, {
+    backgroundColor: '#6366F1',
+    borderRadius: 28,
+    hoverStyle: {
+      backgroundColor: '#5a5fcf',
+    },
+    pressStyle: {
+      backgroundColor: '#5a5fcf',
+    },
+    maxWidth: 500,
+
+    // Shaddows
+    shadowColor: '#000',
+    shadowOffset: {
+      height: 2,
+      width: 0,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 3.84,
+
+    // Button text
+    color: '#FFFFFF',
+    fontWeight: '600', // Is not passed down to the text. Probably a bug in Tamagui: https://github.com/tamagui/tamagui/issues/1156#issuecomment-1802594930
+    fontSize: 16,
+  });
 <% } %>
 
 const config = createTamagui({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Your title should include which part of the project your PR applies to (ex: [cli], [docs], [www]) -->

## Description

<!--- Describe your changes in detail -->
<!--- If your PR affects visual changes then please provide before and after images, gifs, or videos (below) -->

The `components/Button` when using tamagui had wrong types. 

This pr:
- Changes the underlying component used for the tamagui button from `YStack` + `SizebleText` to `Button`
- Generates the styled button in `tamagui.config.js` when navigation is enabled, not only when using a Stack, because we generate the button component always, even if the Tabs and Drawer template are not using it. 
- Fixes custom button types `forwardRef<TamaguiElement, ButtonProps>`
- Custom button component now extends the types of the Tamagui Button
```
type ButtonProps = {
  title: string;
} & ComponentProps<typeof TButton>;
```
- Sends the rest of tamagui button props down to the component `<TButton {...tButtonProps} ref={ref}>`
   - This allows us to use the Custom Button with all available tamagui props.  

## Related Issue
https://github.com/danstepanov/create-expo-stack/issues/275

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue linked above, you can remove this section -->

## How Has This Been Tested?
- Create a new project with Expo Router Stack + Tamagui
- passed the `npx tsc --noEmit`
- Monkey tested the button and it works

## Screenshots (if appropriate):
