### PR TITLE
fix: swap SafeAreaView for react-native-safe-area-context (closes #539)

### DIFF
--- a/cli/src/templates/base/components/Container.tsx.ejs
+++ b/cli/src/templates/base/components/Container.tsx.ejs
@@ -1,4 +1,5 @@
-import { StyleSheet, SafeAreaView } from 'react-native';
+import { StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export const Container = ({ children }: { children: React.ReactNode }) => {
   return <SafeAreaView style={styles.container}>{children}</SafeAreaView>;

--- a/cli/src/templates/packages/nativewindui/components/Container.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/components/Container.tsx.ejs
@@ -1,4 +1,5 @@
-import { StyleSheet, SafeAreaView } from 'react-native';
+import { StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export const Container = ({ children }: { children: React.ReactNode }) => {
   return <SafeAreaView style={styles.container}>{children}</SafeAreaView>;


### PR DESCRIPTION
## Summary

Closes #539 — swaps `SafeAreaView` from `react-native` to `react-native-safe-area-context` in the Container component templates.

### Problem
React Native's built-in `SafeAreaView` only works on iOS and doesn't properly handle notches, dynamic islands, or Android safe areas. The project already uses `react-native-safe-area-context` (`SafeAreaProvider` in layout files), but the Container components still import from `react-native`.

### Changes
- `cli/src/templates/base/components/Container.tsx.ejs` — Import from `react-native-safe-area-context` instead of `react-native`
- `cli/src/templates/packages/nativewindui/components/Container.tsx.ejs` — Same change

### Why this is safe
`react-native-safe-area-context` is already a dependency in generated projects (used by `SafeAreaProvider` in App.tsx/layout files). This is just making the Container component consistent with the rest of the template.