### PR TITLE
Point CLI outro at the Ronin booking funnel

### DIFF
--- a/.changeset/ronin-cli-cta.md
+++ b/.changeset/ronin-cli-cta.md
@@ -1,0 +1,6 @@
+---
+'create-expo-stack': patch
+'rn-new': patch
+---
+
+Point the post-scaffold CLI outro at the Ronin booking funnel (ronindevs.com) instead of a bare email.

--- a/cli/src/utilities/printOutput.ts
+++ b/cli/src/utilities/printOutput.ts
@@ -259,5 +259,7 @@ export async function printOutput(
     info(``);
   }
 
-  outro(`If you're looking to move even faster, I may be able to help!\n- ces@danstepanov.com`);
+  outro(
+    `If you're looking to move even faster, the team at Ronin can help you build it:\n- https://ronindevs.com/?utm_source=rn_new&utm_medium=cli`
+  );
 }


### PR DESCRIPTION
The final message printed after scaffolding already offered help, but via a bare email (`ces@danstepanov.com`). This points it at ronindevs.com instead, tagged `utm_source=rn_new&utm_medium=cli`, so the highest-intent moment in the funnel (a dev who just generated a new app) is tracked and routes to a booking.

One-line change to the existing outro, plus a patch changeset. `tsc -p .` passes. Targeting `next`. Left for your review and your next publish, not merged.