### PR TITLE
Add a Ronin CTA to the site footer

### DIFF
--- a/www/src/components/landing/footer/footer.astro
+++ b/www/src/components/landing/footer/footer.astro
@@ -98,6 +98,18 @@ const [major, minor] = version.split(".").slice(0, 2);
       license.
     </span>
     <span class="text-sm">
+      Built by the team at{" "}
+      <a
+        target="_blank"
+        rel="noreferrer noopener"
+        href="https://ronindevs.com/?utm_source=rn_new&utm_medium=site"
+        class="font-normal text-white underline decoration-wavy underline-offset-4 hover:underline-offset-1 hover:decoration-wavy duration-300"
+      >
+        Ronin
+      </a>
+      . Need a hand with your app? We can help.
+    </span>
+    <span class="text-sm">
       The Expo name and logo are trademarks of 650 Industries, Inc.
     </span>
   </div>


### PR DESCRIPTION
Adds one understated line to the www footer linking the team behind create-expo-stack to ronindevs.com, tagged `utm_source=rn_new&utm_medium=site`. Matches the footer's existing wavy-underline style. Companion to the CLI outro change in #581; together they wire the rn.new channel into the booking funnel.

Targeting `next`. Left for your review, not merged (it deploys the site).