### PR TITLE
Point CLI outro at the Ronin booking funnel (next)

### DIFF
--- a/cli/src/utilities/printOutput.ts
+++ b/cli/src/utilities/printOutput.ts
@@ -259,5 +259,7 @@ export async function printOutput(
     info(``);
   }
 
-  outro(`If you're looking to move even faster, I may be able to help!\n- ces@danstepanov.com`);
+  outro(
+    `If you're looking to move even faster, the team at Ronin can help you build it:\n- https://ronindevs.com/?utm_source=rn_new&utm_medium=cli`
+  );
 }


### PR DESCRIPTION
Same change as #581, applied to `next` so the active dev line matches `main` (the two branches have not been cross-merged since Oct 2025). Code only; the changeset lives on the `main` PR (#581) since releases publish from main.