### PR TITLE
Document the main/next branch model in contributing.md

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -54,6 +54,9 @@ git checkout -b <BRANCH_NAME>
 
 When you're ready to submit your changes, push your branch to your forked repository and open a pull request against the `main` branch of the source repository.
 
+> [!NOTE]
+> `main` tracks the current stable Expo version, while `next` tracks the upcoming beta. `next` is eventually merged into `main` once that beta becomes stable. Open your PR against `main`. If a change applies to both lines (for example a copy or docs tweak that isn't tied to a specific Expo version), open it against both `main` and `next`, since the two branches are not automatically kept in sync.
+
 From here, you can run `bun install` to install all the dependencies for the project.
 
 ### Directory structure


### PR DESCRIPTION
Adds a short note to the contribution workflow explaining that `main` tracks the stable Expo version and `next` tracks the upcoming beta (eventually merged into `main`), and that changes applying to both lines should be opened against both branches since they are not auto-synced. Fills a gap that currently makes it easy to infer the wrong target branch.