### PR TITLE
Remove the by-onlydans / MIT credit line from the site footer

### DIFF
--- a/www/src/components/landing/footer/footer.astro
+++ b/www/src/components/landing/footer/footer.astro
@@ -77,27 +77,6 @@ const [major, minor] = version.split(".").slice(0, 2);
     The most configurable way to create an Expo app.
     <br />
     <span class="text-sm">
-      by @
-      <a
-        target="_blank"
-        rel="noreferrer noopener"
-        href="https://twitter.com/danstepanov"
-        class="font-normal text-white underline decoration-wavy underline-offset-4 hover:underline-offset-1 hover:decoration-wavy duration-300"
-      >
-        onlydans
-      </a>{" "}
-      under the{" "}
-      <a
-        target="_blank"
-        rel="noreferrer noopener"
-        href="https://github.com/roninoss/create-expo-stack?tab=MIT-1-ov-file#readme"
-        class="font-normal text-white underline decoration-wavy underline-offset-4 hover:underline-offset-1 hover:decoration-wavy duration-300"
-      >
-        MIT
-      </a>{" "}
-      license.
-    </span>
-    <span class="text-sm">
       Built by the team at{" "}
       <a
         target="_blank"


### PR DESCRIPTION
Removes the "by @onlydans under the MIT license." line from the expostack.dev / rn.new footer. The license itself is unaffected (still in LICENSE and package.json); this only drops the footer credit line. The merged "Built by Ronin" line and the trademark line remain. Companion PR against `next` to follow.