### PR TITLE
ci: run CLI tests on pull requests and add macOS to the matrix

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,15 +1,26 @@
 on:
   push:
+    branches: [main]
+    paths: ['cli/**']
+  pull_request:
     paths: ['cli/**']
 name: run-tests
+concurrency:
+  group: run-tests-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   build-and-test:
-    name: build-and-test
-    runs-on: ubuntu-latest
+    name: build-and-test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     defaults:
       run:
         shell: bash
         working-directory: cli
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
The run-tests workflow only fires on push, so pull requests from forks never get CI. This adds a pull_request trigger for changes under cli/**, narrows the push trigger to main so branches with open PRs don't run twice, and runs the same suite on macOS alongside ubuntu. It also adds a concurrency group to cancel superseded runs and a 90 minute job timeout. No changes to the tests themselves.

Windows should join the matrix once #580 lands. The suite on main lists generated files with Bun shell find, which has no builtin on Windows, and #580 replaces it with a portable listing built on node fs.