### PR TITLE
fix: guard vexo init when no API key is present

### DIFF
--- a/cli/src/templates/base/App.tsx.ejs
+++ b/cli/src/templates/base/App.tsx.ejs
@@ -20,7 +20,10 @@ import { StatusBar } from 'expo-status-bar';
 <% if (props.analyticsPackage?.name === "vexo-analytics") { %>
   import { vexo } from 'vexo-analytics';
 
-  vexo(process.env.EXPO_PUBLIC_VEXO_API_KEY);
+  const vexoApiKey = process.env.EXPO_PUBLIC_VEXO_API_KEY;
+  if (vexoApiKey) {
+    vexo(vexoApiKey);
+  }
 <% } %>
 
 export default function App() {

--- a/cli/src/templates/base/App.tsx.ejs
+++ b/cli/src/templates/base/App.tsx.ejs
@@ -18,10 +18,9 @@ import { StatusBar } from 'expo-status-bar';
 <% } %>
 
 <% if (props.analyticsPackage?.name === "vexo-analytics") { %>
-  import { vexo } from 'vexo-analytics';
-
   const vexoApiKey = process.env.EXPO_PUBLIC_VEXO_API_KEY;
   if (vexoApiKey) {
+    const { vexo } = require('vexo-analytics');
     vexo(vexoApiKey);
   }
 <% } %>

--- a/cli/src/templates/packages/expo-router/drawer/app/_layout.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/drawer/app/_layout.tsx.ejs
@@ -21,7 +21,10 @@ import { Stack } from 'expo-router';
 <% if (props.analyticsPackage?.name === "vexo-analytics") { %>
   import { vexo } from 'vexo-analytics';
 
-  vexo(process.env.EXPO_PUBLIC_VEXO_API_KEY);
+  const vexoApiKey = process.env.EXPO_PUBLIC_VEXO_API_KEY;
+  if (vexoApiKey) {
+    vexo(vexoApiKey);
+  }
 <% } %>
 
 export const unstable_settings = {

--- a/cli/src/templates/packages/expo-router/drawer/app/_layout.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/drawer/app/_layout.tsx.ejs
@@ -19,10 +19,9 @@ import { Stack } from 'expo-router';
 <% } %>
 
 <% if (props.analyticsPackage?.name === "vexo-analytics") { %>
-  import { vexo } from 'vexo-analytics';
-
   const vexoApiKey = process.env.EXPO_PUBLIC_VEXO_API_KEY;
   if (vexoApiKey) {
+    const { vexo } = require('vexo-analytics');
     vexo(vexoApiKey);
   }
 <% } %>

--- a/cli/src/templates/packages/expo-router/stack/app/_layout.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/stack/app/_layout.tsx.ejs
@@ -12,10 +12,9 @@
 	import { Stack } from "expo-router";
 
 <% if (props.analyticsPackage?.name === "vexo-analytics") { %>
-  import { vexo } from 'vexo-analytics';
-
   const vexoApiKey = process.env.EXPO_PUBLIC_VEXO_API_KEY;
   if (vexoApiKey) {
+    const { vexo } = require('vexo-analytics');
     vexo(vexoApiKey);
   }
 <% } %>

--- a/cli/src/templates/packages/expo-router/stack/app/_layout.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/stack/app/_layout.tsx.ejs
@@ -14,7 +14,10 @@
 <% if (props.analyticsPackage?.name === "vexo-analytics") { %>
   import { vexo } from 'vexo-analytics';
 
-  vexo(process.env.EXPO_PUBLIC_VEXO_API_KEY);
+  const vexoApiKey = process.env.EXPO_PUBLIC_VEXO_API_KEY;
+  if (vexoApiKey) {
+    vexo(vexoApiKey);
+  }
 <% } %>
 
 export default function Layout() {

--- a/cli/src/templates/packages/expo-router/tabs/app/_layout.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/tabs/app/_layout.tsx.ejs
@@ -13,10 +13,9 @@
 	import { Stack } from "expo-router";
 
 <% if (props.analyticsPackage?.name === "vexo-analytics") { %>
-  import { vexo } from 'vexo-analytics';
-
   const vexoApiKey = process.env.EXPO_PUBLIC_VEXO_API_KEY;
   if (vexoApiKey) {
+    const { vexo } = require('vexo-analytics');
     vexo(vexoApiKey);
   }
 <% } %>

--- a/cli/src/templates/packages/expo-router/tabs/app/_layout.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/tabs/app/_layout.tsx.ejs
@@ -15,7 +15,10 @@
 <% if (props.analyticsPackage?.name === "vexo-analytics") { %>
   import { vexo } from 'vexo-analytics';
 
-  vexo(process.env.EXPO_PUBLIC_VEXO_API_KEY);
+  const vexoApiKey = process.env.EXPO_PUBLIC_VEXO_API_KEY;
+  if (vexoApiKey) {
+    vexo(vexoApiKey);
+  }
 <% } %>
 
 export const unstable_settings = {

--- a/cli/src/templates/packages/react-navigation/App.tsx.ejs
+++ b/cli/src/templates/packages/react-navigation/App.tsx.ejs
@@ -23,7 +23,10 @@ import "react-native-gesture-handler";
 <% if (props.analyticsPackage?.name === "vexo-analytics") { %>
   import { vexo } from 'vexo-analytics';
 
-  vexo(process.env.VEXO_API_KEY); // eslint-disable-line
+  const vexoApiKey = process.env.VEXO_API_KEY;
+  if (vexoApiKey) {
+    vexo(vexoApiKey); // eslint-disable-line
+  }
 
   import Navigation from "./navigation"; // eslint-disable-line
 <% } else { %>

--- a/cli/src/templates/packages/react-navigation/App.tsx.ejs
+++ b/cli/src/templates/packages/react-navigation/App.tsx.ejs
@@ -21,7 +21,7 @@ import { useMemo } from 'react';
 import "react-native-gesture-handler";
 
 <% if (props.analyticsPackage?.name === "vexo-analytics") { %>
-  const vexoApiKey = process.env.VEXO_API_KEY;
+  const vexoApiKey = process.env.EXPO_PUBLIC_VEXO_API_KEY;
   if (vexoApiKey) {
     const { vexo } = require('vexo-analytics');
     vexo(vexoApiKey); // eslint-disable-line

--- a/cli/src/templates/packages/react-navigation/App.tsx.ejs
+++ b/cli/src/templates/packages/react-navigation/App.tsx.ejs
@@ -21,10 +21,9 @@ import { useMemo } from 'react';
 import "react-native-gesture-handler";
 
 <% if (props.analyticsPackage?.name === "vexo-analytics") { %>
-  import { vexo } from 'vexo-analytics';
-
   const vexoApiKey = process.env.VEXO_API_KEY;
   if (vexoApiKey) {
+    const { vexo } = require('vexo-analytics');
     vexo(vexoApiKey); // eslint-disable-line
   }
 


### PR DESCRIPTION
## Summary
- split out of #580
- guards `vexo()` initialization when no API key is present
- keeps the fix self-contained instead of pointing back to the now-closed #579 reference

## Included
- base template guard
- Expo Router drawer / stack / tabs guards
- React Navigation template guard

## Verification
- `git diff --check`
- `bun run build:cli`
- `cd cli && bun test --bail=1 --timeout 160000` (still hits the pre-existing Windows harness issue that is split into the tooling PR)