### PR TITLE
chore: add changeset for Expo SDK 56 upgrade

### DIFF
--- a/.changeset/expo-sdk-56-upgrade.md
+++ b/.changeset/expo-sdk-56-upgrade.md
@@ -1,0 +1,14 @@
+---
+'create-expo-stack': minor
+'rn-new': minor
+---
+
+Upgrade generated templates to Expo SDK 56 and harden the CLI tooling.
+
+- Upgrade generated app dependencies to Expo SDK 56, React 19.2, React Native 0.85, Expo Router 6, React Navigation 7, Reanimated 4, and related Expo packages.
+- Switch generated `app.json` splash configuration to the `expo-splash-screen` plugin, add a generated `css-env.d.ts` so TypeScript accepts CSS imports, and update generated `tsconfig.json` output for TypeScript 6 behavior.
+- Derive Expo-safe `slug` and `scheme` from the project name via new `toExpoSlug` and `toExpoScheme` helpers, while preserving the display name the user entered.
+- Raise the minimum Node version gate to 20.19.4 and clarify the error message branding.
+- Remove remaining Restyle and Tamagui residue from templates, docs, and public assets.
+- Guard `vexo()` initialization in the base, Expo Router, and React Navigation templates when no API key is present.
+- Make the CLI test harness and generation tooling Windows safe, including cwd/env handling and shell quoting in system commands, and refresh integration snapshots to match the SDK 56 scaffold output.


### PR DESCRIPTION
David's recently merged PRs landed without changesets, so no release was queued. This adds a single changeset to cut a minor version covering all of them.

Covers:
- #599 feat: upgrade templates to Expo SDK 56
- #598 test: make the CLI harness Windows-safe
- #597 fix: guard vexo init when no API key is present
- #596 chore: remove legacy styling residue

Bumps `create-expo-stack` and `rn-new` (fixed group) by a minor version.