### PR TITLE
ci: run release workflows on Node 22

### DIFF
--- a/.github/workflows/next-release.yaml
+++ b/.github/workflows/next-release.yaml
@@ -93,7 +93,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: latest
+          node-version: 22
 
       - name: Authenticate to npm and publish
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 22
 
       - name: Cache node_modules
         id: cache-bun


### PR DESCRIPTION
## Why
The Release workflow has been failing on `Create Release Pull Request` ([example run](https://github.com/roninoss/create-expo-stack/actions/runs/28220168099/job/83599436858)):

```
Error [ERR_REQUIRE_ESM]: require() of ES Module .../human-id/dist/index.js
from .../@changesets/write/dist/changesets-write.cjs.js not supported.
Node.js v18.20.8
```

The refreshed root lockfile floated the changesets dependency tree up, and the newer `@changesets/write` now pulls in an ESM-only `human-id`. `release.yaml` pinned `node-version: 18`, and Node 18 cannot `require()` an ES module, so `changeset version` crashed before opening the release PR. `next-release.yaml` used `latest` and was unaffected.

## Change
- Bump `release.yaml` to Node 22 (Node 20.19+/22.12+ support `require()` of ESM). This also matches the Node 20.19.4+ minimum introduced with the Expo SDK 56 work.
- Pin `next-release.yaml` off floating `latest` to the same Node 22 for determinism.

After this merges, re-running the Release job will pick up the pending changeset and open the version PR.