### PR TITLE
[cli] Fix Nativewind home layout and rerun-hint quoting

### DIFF
--- a/.changeset/nativewind-home-layout.md
+++ b/.changeset/nativewind-home-layout.md
@@ -1,0 +1,6 @@
+---
+'create-expo-stack': patch
+'rn-new': patch
+---
+
+Fix Nativewind template layout: inset the Show Details button from the screen edges and constrain EditScreenInfo so its description text wraps instead of clipping.

--- a/.changeset/rerun-hint-quoting.md
+++ b/.changeset/rerun-hint-quoting.md
@@ -1,0 +1,6 @@
+---
+'create-expo-stack': patch
+'rn-new': patch
+---
+
+Only quote the project name in the rerun hint when it contains characters that need shell quoting.

--- a/cli/src/templates/packages/expo-router/stack/app/index.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/stack/app/index.tsx.ejs
@@ -65,7 +65,7 @@ export default function Home() {
 <% if (props.stylingPackage?.name === "nativewind") { %>
 const styles = {
   container: "flex flex-1 p-safe bg-white",
-  buttonWrapper: "w-full pb-safe",
+  buttonWrapper: "w-full px-6 pb-safe",
 };
 <% } else if (props.stylingPackage?.name === "stylesheet") { %>
 const styles = StyleSheet.create({

--- a/cli/src/templates/packages/nativewind/components/EditScreenInfo.tsx.ejs
+++ b/cli/src/templates/packages/nativewind/components/EditScreenInfo.tsx.ejs
@@ -19,7 +19,7 @@ export const EditScreenInfo: React.FC<EditScreenInfoProps> = ({ path }) => {
   const description = "Change any of the text, save the file, and your app will automatically update."
 <% } %>
   return (
-    <View>
+    <View className={styles.container}>
       <View className={styles.getStartedContainer}>
         <Text className={styles.getStartedText}>{title}</Text>
         <View className={`${styles.codeHighlightContainer} ${styles.homeScreenFilename}`}>
@@ -34,6 +34,7 @@ export const EditScreenInfo: React.FC<EditScreenInfoProps> = ({ path }) => {
 };
 
 const styles = {
+  container: `w-full`,
   codeHighlightContainer: `rounded-md px-1`,
   getStartedContainer: `items-center mx-12`,
   getStartedText: `text-lg leading-6 text-center`,

--- a/cli/src/utilities/systemCommand.ts
+++ b/cli/src/utilities/systemCommand.ts
@@ -5,6 +5,11 @@ type STDIO = 'inherit' | 'ignore' | 'pipe' | 'overlapped';
 export const ONLY_ERRORS = ['ignore', 'ignore', 'inherit'] as const;
 
 export function quoteShellArg(value: string): string {
+  // Values made of safe characters don't need quoting on any platform
+  if (/^[A-Za-z0-9._-]+$/.test(value)) {
+    return value;
+  }
+
   if (process.platform === 'win32') {
     return `"${value.replace(/"/g, '""')}"`;
   }


### PR DESCRIPTION
## Description

Three small fixes for issues spotted while testing generated apps:

- **Description text clipped mid-sentence**: `ScreenContent` centers its children (`items-center`), so `EditScreenInfo`'s unconstrained outer `View` sized itself to the text's intrinsic single-line width and the description clipped at the screen edge ("Change any of the text, save the file, and…"). Give the outer `View` `w-full` so the text wraps within the screen.
- **Show Details button touched the screen edges**: the stack home screen's button wrapper only had safe-area padding, which is zero horizontally on iPhones in portrait. Add `px-6`.
- **Rerun hint quoted every project name**: the "To recreate this project" command showed `npx rn-new@latest 'my-app'` even for names that need no quoting. `quoteShellArg` now returns safe-charset values unchanged and only quotes names with spaces or other special characters.

## Related Issue

N/A — spotted during manual testing of generated apps.

## Motivation and Context

Fresh `--nativewind --expo-router` projects had visibly broken layout on first launch.

## How Has This Been Tested?

- `bun run build` (tsc + ejslint) passes
- Generated `--nativewind --expo-router` projects and verified the new classes land in the output and the project typechecks (`tsc --noEmit` exit 0)
- Verified the rerun hint prints `quotetest` unquoted and `'quote test'` quoted

## Screenshots (if appropriate):

Before: button spans the full screen width; description text ends mid-sentence at the screen edge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K3jJFYeT94SK6pams42EsM)_