### PR TITLE
[cli] Fix Nativewind home layout, TabBarIcon types, and rerun-hint quoting

### DIFF
--- a/.changeset/nativewind-home-layout.md
+++ b/.changeset/nativewind-home-layout.md
@@ -1,0 +1,6 @@
+---
+'create-expo-stack': patch
+'rn-new': patch
+---
+
+Fix Nativewind template layout: inset the Show Details button from the screen edges, constrain EditScreenInfo so its description text wraps instead of clipping, type TabBarIcon color as ColorValue for SDK 56 tabs, and only quote the rerun-hint project name when it needs shell quoting.

--- a/cli/src/templates/base/components/TabBarIcon.tsx.ejs
+++ b/cli/src/templates/base/components/TabBarIcon.tsx.ejs
@@ -1,9 +1,9 @@
 import FontAwesome from '@expo/vector-icons/FontAwesome';
-import { StyleSheet } from 'react-native';
+import { ColorValue, StyleSheet } from 'react-native';
 
 export const TabBarIcon = (props: {
   name: React.ComponentProps<typeof FontAwesome>['name'];
-  color: string;
+  color: ColorValue;
 }) => {
   return <FontAwesome size={28} style={styles.tabBarIcon} {...props} />;
 };

--- a/cli/src/templates/packages/expo-router/stack/app/index.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/stack/app/index.tsx.ejs
@@ -33,6 +33,8 @@ export default function Home() {
         <Link href={{ pathname: '/details', params: { name: 'Dan' } }} asChild>
           <% if (props.stylingPackage?.name === "unistyles") { %>
               <Button title="Show Details" style={styles.button} />
+          <% } else if (props.stylingPackage?.name === "nativewind") { %>
+              <Button title="Show Details" className="mx-6" />
           <% } else { %>
               <Button title="Show Details" />
           <% } %>

--- a/cli/src/templates/packages/nativewind/components/EditScreenInfo.tsx.ejs
+++ b/cli/src/templates/packages/nativewind/components/EditScreenInfo.tsx.ejs
@@ -18,7 +18,7 @@ export const EditScreenInfo: React.FC<EditScreenInfoProps> = ({ path }) => {
   const description = "Change any of the text, save the file, and your app will automatically update."
 <% } %>
   return (
-    <View>
+    <View className={styles.container}>
       <View className={styles.getStartedContainer}>
         <Text className={styles.getStartedText}>{title}</Text>
         <View className={`${styles.codeHighlightContainer} ${styles.homeScreenFilename}`}>
@@ -33,6 +33,7 @@ export const EditScreenInfo: React.FC<EditScreenInfoProps> = ({ path }) => {
 };
 
 const styles = {
+  container: `w-full`,
   codeHighlightContainer: `rounded-md px-1`,
   getStartedContainer: `items-center mx-12`,
   getStartedText: `text-lg leading-6 text-center`,

--- a/cli/src/utilities/systemCommand.ts
+++ b/cli/src/utilities/systemCommand.ts
@@ -5,6 +5,11 @@ type STDIO = 'inherit' | 'ignore' | 'pipe' | 'overlapped';
 export const ONLY_ERRORS = ['ignore', 'ignore', 'inherit'] as const;
 
 export function quoteShellArg(value: string): string {
+  // Values made of safe characters don't need quoting on any platform
+  if (/^[A-Za-z0-9._-]+$/.test(value)) {
+    return value;
+  }
+
   if (process.platform === 'win32') {
     return `"${value.replace(/"/g, '""')}"`;
   }


### PR DESCRIPTION
## Description

Mirror of #611 for the v4 (main) templates, plus one main-only fix:

- **Description text clipped mid-sentence**: `ScreenContent` centers its children (`items-center`), so `EditScreenInfo`'s unconstrained outer `View` sized itself to the text's intrinsic single-line width and the description clipped at the screen edge. Give it `w-full` so the text wraps.
- **Show Details button touched the screen edges**: `Container` only has `p-safe`, which is zero horizontally on iPhones in portrait, and the stretched button spanned edge to edge. Add `mx-6` to the button on the Nativewind stack home screen.
- **TabBarIcon color type** (main-only): Expo Router's `Tabs` on SDK 56 passes `ColorValue` to `tabBarIcon`, which fails `tsc` against the base `TabBarIcon`'s `color: string`. Type it as `ColorValue` — `@expo/vector-icons` accepts `string | OpaqueColorValue`, so both Expo Router and React Navigation callers fit. (Not caught by CI because main's matrix doesn't include `--nativewind --expo-router --tabs`.)
- **Rerun hint quoted every project name**: `quoteShellArg` now returns safe-charset values unchanged and only quotes names with spaces or other special characters.

## Related Issue

N/A — spotted during manual testing of generated apps. Same fixes applied to `next` in #611.

## Motivation and Context

Fresh `--nativewind --expo-router` projects had visibly broken layout on first launch, and `--nativewind --expo-router --tabs` projects fail typechecking on SDK 56.

## How Has This Been Tested?

- `bun run build` (tsc + ejslint) passes
- Generated a `--nativewind --expo-router` project: new classes present in output, `tsc --noEmit` exits 0
- Verified the rerun hint prints bare names unquoted and quotes names containing spaces

## Screenshots (if appropriate):

Before: button spans the full screen width; description text ends mid-sentence at the screen edge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K3jJFYeT94SK6pams42EsM)_